### PR TITLE
Correcting a small typo in the badges section

### DIFF
--- a/i18n/src/main/res/values/strings.xml
+++ b/i18n/src/main/res/values/strings.xml
@@ -210,7 +210,7 @@
     <string name="preference_screen_badges_summary">Configure icon badges</string>
     <string name="preference_notification_badges">Notification badges</string>
     <string name="preference_notification_badges_summary">Show a badge for applications with unread notifications</string>
-    <string name="preference_suspended_badges_summary">Show a badge for suspended applicatoins</string>
+    <string name="preference_suspended_badges_summary">Show a badge for suspended applications</string>
     <string name="preference_suspended_badges">Suspended apps</string>
     <string name="preference_cloud_badges">Cloud badges</string>
     <string name="preference_cloud_badges_summary">Show a badge for files that are stored in a cloud</string>


### PR DESCRIPTION
Hello,

Just a small pr to correct a typo in the badges section, which I found while translating the strings. 
Also, in a few days, I will open another pr to add a French translation of the app.

Thanks for this great launcher!
