### PR TITLE
Add permission ACCESS_RESTRICTED_SETTINGS

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,6 +26,7 @@
     <uses-permission android:name="android.permission.REQUEST_DELETE_PACKAGES" />
 
     <uses-permission android:name="android.permission.VIBRATE" />
+    <uses-permission android:name="android.permission.ACCESS_RESTRICTED_SETTINGS" />
 
     <application
         android:name=".LauncherApplication"


### PR DESCRIPTION
This is needed on android13 for device- and app-notification permission. This is block for sideloaded apps