### PR TITLE
add Oneplus clock widget

### DIFF
--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/widgets/clock/ClockWidget.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/widgets/clock/ClockWidget.kt
@@ -35,6 +35,7 @@ import de.mm20.launcher2.ui.launcher.widgets.clock.clocks.AnalogClock
 import de.mm20.launcher2.ui.launcher.widgets.clock.clocks.BinaryClock
 import de.mm20.launcher2.ui.launcher.widgets.clock.clocks.DigitalClock1
 import de.mm20.launcher2.ui.launcher.widgets.clock.clocks.DigitalClock2
+import de.mm20.launcher2.ui.launcher.widgets.clock.clocks.OneClock
 import de.mm20.launcher2.ui.launcher.widgets.clock.clocks.OrbitClock
 import de.mm20.launcher2.ui.launcher.widgets.clock.parts.PartProvider
 import de.mm20.launcher2.ui.locals.LocalPreferDarkContentOverWallpaper
@@ -160,8 +161,9 @@ fun Clock(
     val time = LocalTime.current
     when (style) {
         ClockStyle.DigitalClock1 -> DigitalClock1(time, layout)
+        ClockStyle.OneClock -> OneClock(time, layout)
         ClockStyle.DigitalClock2 -> DigitalClock2(time, layout)
-        ClockStyle.BinaryClock -> BinaryClock(time, layout)
+        ClockStyle.BinaryClock -> BinaryClock(time,  layout)
         ClockStyle.AnalogClock -> AnalogClock(time, layout)
         ClockStyle.OrbitClock -> OrbitClock(time, layout)
         ClockStyle.EmptyClock -> {}

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/widgets/clock/clocks/OneClock.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/widgets/clock/clocks/OneClock.kt
@@ -1,0 +1,65 @@
+package de.mm20.launcher2.ui.launcher.widgets.clock.clocks
+
+import android.text.format.DateFormat
+import androidx.compose.foundation.layout.offset
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
+import de.mm20.launcher2.preferences.Settings
+import java.text.SimpleDateFormat
+import java.util.*
+
+@Composable
+fun OneClock(
+    time: Long,
+    layout: Settings.ClockWidgetSettings.ClockWidgetLayout
+) {
+    val verticalLayout = layout == Settings.ClockWidgetSettings.ClockWidgetLayout.Vertical
+    val format = SimpleDateFormat(
+        if (verticalLayout) {
+            if (DateFormat.is24HourFormat(LocalContext.current)) "HH\nmm" else "hh\nmm"
+        } else {
+            if (DateFormat.is24HourFormat(LocalContext.current)) "HH mm" else "hh mm"
+        },
+        Locale.getDefault()
+    )
+    val formattedString = format.format(time)
+
+    val hour = formattedString.substring(0, 2)
+
+    val annotatedString = buildAnnotatedString {
+        hour.forEach {
+            if (it == '1') {
+                withStyle(style = SpanStyle(color = Color(0xFFC41442))) {
+                    append(it)
+                }
+            } else {
+                append(it)
+            }
+        }
+        append(formattedString.substring(2))
+    }
+
+
+    Text(
+        modifier = Modifier.offset(0.dp, if (verticalLayout) 16.dp else 0.dp),
+        text = annotatedString,
+        style = MaterialTheme.typography.displayLarge.copy(
+            fontSize = if (verticalLayout) 100.sp else 48.sp,
+            fontWeight = FontWeight.Black,
+            textAlign = TextAlign.Center,
+            lineHeight = 0.8.em,
+        )
+    )
+}

--- a/core/preferences/src/main/proto/settings.proto
+++ b/core/preferences/src/main/proto/settings.proto
@@ -111,12 +111,12 @@ message Settings {
     ClockWidgetLayout layout = 1;
     enum ClockStyle {
       DigitalClock1 = 0;
-      OneClock = 1;
-      DigitalClock2 = 2;
-      OrbitClock = 3;
-      BinaryClock = 4;
-      AnalogClock = 5;
-      EmptyClock = 6;
+      OneClock = 6;
+      DigitalClock2 = 1;
+      OrbitClock = 5;
+      BinaryClock = 2;
+      AnalogClock = 3;
+      EmptyClock = 4;
     }
     ClockStyle clock_style = 2;
     bool date_part = 3;

--- a/core/preferences/src/main/proto/settings.proto
+++ b/core/preferences/src/main/proto/settings.proto
@@ -111,11 +111,12 @@ message Settings {
     ClockWidgetLayout layout = 1;
     enum ClockStyle {
       DigitalClock1 = 0;
-      DigitalClock2 = 1;
-      OrbitClock = 5;
-      BinaryClock = 2;
-      AnalogClock = 3;
-      EmptyClock = 4;
+      OneClock = 1;
+      DigitalClock2 = 2;
+      OrbitClock = 3;
+      BinaryClock = 4;
+      AnalogClock = 5;
+      EmptyClock = 6;
     }
     ClockStyle clock_style = 2;
     bool date_part = 3;


### PR DESCRIPTION
I understand that there are many OnePlus users who may not appreciate the red color option available in the OnePlus clock widget. However, after having it on my home and lock screen for years, I have developed a fondness for it. Nevertheless I genuinely enjoy using this launcher and appreciate the digital clock widgets it already offers. However, I do miss having a touch of red on my home screen. That's why I have made the decision to create a pull request that introduces a new digital clock widget. In this widget, the hour digits will be colored red specifically when they represent the number one.
![Screenshot_2023-06-08-11-57-35-43_b50c6ccf92c546ed20b65090255147e8](https://github.com/MM2-0/Kvaesitso/assets/103252381/aa2535f2-fd41-4cf5-be28-d1b83618bbee)
![Screenshot_2023-06-08-11-57-18-88_b50c6ccf92c546ed20b65090255147e8](https://github.com/MM2-0/Kvaesitso/assets/103252381/1b61f83a-d256-46b4-b9ab-9618a7b76702)


