### PR TITLE
add workaround for resource/folder mime types when view activity fails

### DIFF
--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/search/SearchVM.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/search/SearchVM.kt
@@ -89,10 +89,11 @@ class SearchVM : ViewModel(), KoinComponent {
     fun launchBestMatchOrAction(context: Context) {
         val bestMatch = bestMatch.value
         if (bestMatch is SavableSearchable) {
-            bestMatch.launch(context, null)
-            favoritesService.reportLaunch(bestMatch)
+            if (bestMatch.launch(context, null))
+                favoritesService.reportLaunch(bestMatch)
             return
-        } else if (bestMatch is SearchAction) {
+        }
+        if (bestMatch is SearchAction) {
             bestMatch.start(context)
             return
         }

--- a/core/ktx/src/main/java/de/mm20/launcher2/ktx/Context.kt
+++ b/core/ktx/src/main/java/de/mm20/launcher2/ktx/Context.kt
@@ -24,6 +24,18 @@ fun Context.tryStartActivity(intent: Intent, bundle: Bundle? = null): Boolean {
         startActivity(intent, bundle)
         true
     } catch (e: ActivityNotFoundException) {
+        if (intent.type == "resource/folder") {
+            packageManager.getLaunchIntentForPackage("com.android.documentsui")?.let {
+                it.setDataAndType(intent.data, intent.type)
+                    .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_GRANT_READ_URI_PERMISSION)
+
+                return try {
+                    startActivity(it, bundle)
+                    true
+                } catch (_: Exception) { false }
+            }
+        }
+
         false
     } catch (e: SecurityException) {
         false


### PR DESCRIPTION
This is probably specific to grapheneos, but it still fixes a long-standing bug that causes nothing to happen when a SavableSearchable result that is a directory is launched.

This happens because by default, apparently no app implements `Intent.ACTION_VIEW` for mime-type `resource/folder` on grapheneos, even though the default file browser (`com.android.documentsui`) is available.

In that case, just open `com.android.documentsui` directly with the given uri.

Also, this fixes a possible issue where the launchcount is incremented even though launching fails.