### PR TITLE
Fix: don't treat PH OpeningHours with specified time as `everyDay`

### DIFF
--- a/data/openstreetmaps/src/main/java/de/mm20/launcher2/openstreetmaps/OsmLocation.kt
+++ b/data/openstreetmaps/src/main/java/de/mm20/launcher2/openstreetmaps/OsmLocation.kt
@@ -239,8 +239,12 @@ internal fun parseOpeningSchedule(it: String?): OpeningSchedule? {
 
         // if no day specified, treat as "every day"
         if (days.isEmpty()) {
-            everyDay = true
-            days = daysOfWeek.toSet()
+            if (group.any { it.equals("PH", ignoreCase = true) }) {
+                times = emptyList()
+            } else {
+                everyDay = true
+                days = daysOfWeek.toSet()
+            }
         }
 
         openingHours.addAll(days.flatMap { day ->


### PR DESCRIPTION
Quick patch in case you intend to tag a new bugfix release before we possibly migrate parsing opening hours to an external library, as suggested in #860.
