### PR TITLE
Fix TODO: KTIJ-19369 is marked as fixed.

### DIFF
--- a/core/devicepose/build.gradle.kts
+++ b/core/devicepose/build.gradle.kts
@@ -1,4 +1,3 @@
-@Suppress("DSL_SCOPE_VIOLATION") // TODO: Remove once KTIJ-19369 is fixed
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
@@ -6,10 +5,10 @@ plugins {
 
 android {
     namespace = "de.mm20.launcher2.location"
-    compileSdk = 34
+    compileSdk = libs.versions.compileSdk.get().toInt()
 
     defaultConfig {
-        minSdk = 21
+        minSdk = libs.versions.minSdk.get().toInt()
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")


### PR DESCRIPTION
KTIJ-19369 is marked as fixed, so the `@SupressWarnings` can be removed and SDK version pulled from the settings file.