### PR TITLE
Remove unused variable in `CrashReporter`.

### DIFF
--- a/core/crashreporter/src/main/java/de/mm20/launcher2/crashreporter/CrashReporter.kt
+++ b/core/crashreporter/src/main/java/de/mm20/launcher2/crashreporter/CrashReporter.kt
@@ -31,7 +31,6 @@ object CrashReporter {
     }
 
     suspend fun getCrashReport(filePath: String): CrashReport {
-        val path = CrashReporter.getCrashReportPath()?.takeIf { it.isEmpty() } ?: CrashUtil.getDefaultPath()
         return CrashReport.fromFile(File(filePath), true)
     }
 


### PR DESCRIPTION
I presume the idea was to verify that the path is in the crash reports directory, but it's not used and I'm not sure if it's necessary.