### PR TITLE
Calculate values for filter categories from the list of values.

### DIFF
--- a/core/base/src/main/java/de/mm20/launcher2/search/SearchFilters.kt
+++ b/core/base/src/main/java/de/mm20/launcher2/search/SearchFilters.kt
@@ -17,9 +17,11 @@ data class SearchFilters(
     val events: Boolean = true,
     val tools: Boolean = true,
 ) {
+    private val categories = listOf(apps, websites, articles, places, files, shortcuts, contacts, events, tools)
+
     val allCategoriesEnabled
-        get() = apps && websites && articles && places && files && shortcuts && contacts && events && tools
+        get() = categories.all { it }
 
     val enabledCategories: Int
-        get() = apps.toInt() + websites.toInt() + articles.toInt() + places.toInt() + files.toInt() + shortcuts.toInt() + contacts.toInt() + events.toInt() + tools.toInt()
+        get() = categories.count { it }
 }


### PR DESCRIPTION
Save all categories in a list and calculate the properties from said list instead of manually computing all values. This leads to less errors when adding a new category.