### PR TITLE
Query search against application package name in addition to label.

### DIFF
--- a/data/applications/src/main/java/de/mm20/launcher2/applications/AppRepository.kt
+++ b/data/applications/src/main/java/de/mm20/launcher2/applications/AppRepository.kt
@@ -222,7 +222,7 @@ internal class AppRepositoryImpl(
                     appResults.addAll(apps)
                 } else {
                     appResults.addAll(apps.filter {
-                        matches(it.label, query)
+                        matches(it.label, query) || matches(it.componentName.packageName.split('.').last(), query)
                     })
 
                     val componentName = ComponentName.unflattenFromString(query)


### PR DESCRIPTION
When searching apps, compare query against the original app name as well as label to help with i18n. For example, Google suite apps, such as Google Maps, have localised labels in different languages. Google Maps name in Russian is `Карты`, which cause it to not be shown when querying for `map`. Current behaviour:

![image](https://github.com/user-attachments/assets/fc6f5a87-85e1-45f1-a363-165297cf6ab2)

Expected behaviour (after this pull request):
![image](https://github.com/user-attachments/assets/338abd2b-f82b-488a-825b-87c2dc51d84e)
