### PR TITLE
Fix weather sdk providing wrong WeatherLocation

### DIFF
--- a/plugins/sdk/src/main/java/de/mm20/launcher2/sdk/weather/WeatherProvider.kt
+++ b/plugins/sdk/src/main/java/de/mm20/launcher2/sdk/weather/WeatherProvider.kt
@@ -132,7 +132,7 @@ abstract class WeatherProvider(
             return getWeatherData(lat, lon, lang)
         }
         if (id != null && locationName != null) {
-            return getWeatherData(WeatherLocation.Id(id, locationName), lang)
+            return getWeatherData(WeatherLocation.Id(locationName, id), lang)
         }
         if (locationName != null && lat != null && lon != null) {
             return getWeatherData(WeatherLocation.LatLon(locationName, lat, lon), lang)


### PR DESCRIPTION
Hi, a fair warning, I didn't actually test if this fixes anything at all because I was unable to compile the module (Any help with that would be appreciated), but I don't see where else the problem could be so it's probably fine.

So yeah, while making my own plugin I found that when the location is set manually and the plugin is using WeatherLocation.Id, the location provided by the sdk has the name and id switched requiring a workaround for in the plugin and this _should_ address that.