### PR TITLE
Keep music widget overflow menu open

### DIFF
--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/widgets/music/MusicWidget.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/widgets/music/MusicWidget.kt
@@ -447,7 +447,6 @@ fun CustomActions(
                             )
                         },
                         onClick = {
-                            showOverflowMenu = false
                             onActionSelected(action)
                         }
                     )


### PR DESCRIPTION
Whenever a user changes a playback setting in the music widget overflow menu, it is closed, which is quite annoying. For example the loop setting has 3 states meaning that you will almost always want to open the menu a second time just to check whether it has changed to the state you want it to be in as the result is not obvious for non-binary options.