### PR TITLE
Standardize bottom sheets

### DIFF
--- a/app/ui/src/main/java/de/mm20/launcher2/ui/common/ImportThemeSheet.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/common/ImportThemeSheet.kt
@@ -12,8 +12,6 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.DarkMode
 import androidx.compose.material.icons.rounded.ErrorOutline
@@ -69,21 +67,7 @@ fun ImportThemeSheet(
     val error by viewModel.error
     var apply by viewModel.apply
 
-    BottomSheetDialog(
-        onDismissRequest = onDismiss,
-        confirmButton = if (theme != null && !error) {
-            {
-                Button(
-                    onClick = {
-                        viewModel.import()
-                        onDismiss()
-                    }
-                ) {
-                    Text(stringResource(R.string.action_import))
-                }
-            }
-        } else null,
-    ) {
+    BottomSheetDialog(onDismiss) {
         if (theme == null && !error) {
             Box(
                 modifier = Modifier
@@ -111,8 +95,8 @@ fun ImportThemeSheet(
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .verticalScroll(rememberScrollState())
-                    .padding(it)
+                    .padding(it),
+                horizontalAlignment = Alignment.End
             ) {
                 ThemePreview(
                     theme!!,
@@ -131,6 +115,15 @@ fun ImportThemeSheet(
                         onValueChanged = {
                             apply = it
                         })
+                }
+                Button(
+                    modifier = Modifier.padding(top = 8.dp),
+                    onClick = {
+                        viewModel.import()
+                        onDismiss()
+                    },
+                ) {
+                    Text(stringResource(R.string.action_import))
                 }
             }
         }

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/common/RestoreBackupSheet.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/common/RestoreBackupSheet.kt
@@ -2,12 +2,22 @@ package de.mm20.launcher2.ui.common
 
 import android.net.Uri
 import android.text.format.DateUtils
-import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.rounded.*
-import androidx.compose.material3.*
+import androidx.compose.material.icons.rounded.CheckCircleOutline
+import androidx.compose.material.icons.rounded.ErrorOutline
+import androidx.compose.material.icons.rounded.Info
+import androidx.compose.material.icons.rounded.Warning
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -37,29 +47,12 @@ fun RestoreBackupSheet(
     val state by viewModel.state
     val compatibility by viewModel.compatibility
 
-    BottomSheetDialog(
-        onDismissRequest = onDismissRequest,
-        confirmButton = {
-            if (state == RestoreBackupState.Ready && compatibility != BackupCompatibility.Incompatible) {
-                Button(
-                    onClick = { viewModel.restore() }) {
-                    Text(stringResource(R.string.preference_restore))
-                }
-            } else if (state == RestoreBackupState.InvalidFile || state == RestoreBackupState.Restored || state == RestoreBackupState.Ready) {
-                OutlinedButton(
-                    onClick = onDismissRequest
-                ) {
-                    Text(stringResource(R.string.close))
-                }
-            }
-        },
-    ) {
-        Box(
+    BottomSheetDialog(onDismissRequest) {
+        Column (
             modifier = Modifier
                 .fillMaxWidth()
-                .wrapContentHeight()
-                .verticalScroll(rememberScrollState())
-                .padding(it)
+                .padding(it),
+            horizontalAlignment = Alignment.End,
         ) {
             when (state) {
                 RestoreBackupState.Parsing -> {
@@ -151,6 +144,14 @@ fun RestoreBackupSheet(
                             id = R.string.restore_complete
                         )
                     )
+                }
+            }
+
+            if (state == RestoreBackupState.Ready && compatibility != BackupCompatibility.Incompatible) {
+                Button(
+                    onClick = { viewModel.restore() }
+                ) {
+                    Text(stringResource(R.string.preference_restore))
                 }
             }
         }

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/common/RestoreBackupSheet.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/common/RestoreBackupSheet.kt
@@ -39,13 +39,7 @@ fun RestoreBackupSheet(
 
     BottomSheetDialog(
         onDismissRequest = onDismissRequest,
-        title = {
-            Text(
-                stringResource(id = R.string.preference_restore),
-            )
-        },
         confirmButton = {
-
             if (state == RestoreBackupState.Ready && compatibility != BackupCompatibility.Incompatible) {
                 Button(
                     onClick = { viewModel.restore() }) {

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/common/SearchablePicker.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/common/SearchablePicker.kt
@@ -36,12 +36,11 @@ import de.mm20.launcher2.ui.ktx.toPixels
 fun SearchablePicker(
     value: SavableSearchable?,
     onValueChanged: (SavableSearchable?) -> Unit,
-    title: @Composable () -> Unit,
     onDismissRequest: () -> Unit,
 ) {
     val viewModel: SearchablePickerVM = viewModel()
 
-    BottomSheetDialog(onDismissRequest = onDismissRequest, title = title) {
+    BottomSheetDialog(onDismissRequest = onDismissRequest) {
         Column(
             modifier = Modifier
                 .fillMaxSize()

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/common/WeatherLocationSearchDialog.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/common/WeatherLocationSearchDialog.kt
@@ -2,7 +2,7 @@ package de.mm20.launcher2.ui.common
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -11,8 +11,17 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Error
 import androidx.compose.material.icons.rounded.Search
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.SearchBar
+import androidx.compose.material3.SearchBarDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -32,33 +41,39 @@ fun WeatherLocationSearchDialog(
     val isSearching by viewModel.isSearchingLocation
     val locations by viewModel.locationResults
 
-    BottomSheetDialog(
-        onDismissRequest = onDismissRequest
-    ) {
+    BottomSheetDialog(onDismissRequest) {
         var query by remember { mutableStateOf("") }
         Column(
-            modifier = Modifier.fillMaxSize().padding(it)
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(it)
         ) {
-            Row(
-                Modifier.padding(bottom = 16.dp)
-            ) {
-                OutlinedTextField(
-                    singleLine = true,
-                    value = query,
-                    textStyle = MaterialTheme.typography.bodyLarge,
-                    onValueChange = {
-                        query = it
-                        scope.launch {
-                            viewModel.searchLocation(it)
-                        }
-                    },
-                    leadingIcon = {
-                        Icon(imageVector = Icons.Rounded.Search, contentDescription = null)
-                    },
-                    modifier = Modifier
-                        .weight(1f)
-                )
-            }
+            SearchBar(
+                modifier = Modifier.padding(bottom = 8.dp),
+                windowInsets = WindowInsets(0.dp),
+                expanded = false,
+                onExpandedChange = {},
+                inputField = {
+                    SearchBarDefaults.InputField(
+                        leadingIcon = {
+                            Icon(
+                                imageVector = Icons.Rounded.Search,
+                                contentDescription = null
+                            )
+                        },
+                        onSearch = {},
+                        expanded = false,
+                        onExpandedChange = {},
+                        query = query,
+                        onQueryChange = {
+                            query = it
+                            scope.launch {
+                                viewModel.searchLocation(it)
+                            }
+                        },
+                    )
+                }
+            ) {}
             if (isSearching) {
                 CircularProgressIndicator(
                     modifier = Modifier

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/common/WeatherLocationSearchDialog.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/common/WeatherLocationSearchDialog.kt
@@ -33,12 +33,7 @@ fun WeatherLocationSearchDialog(
     val locations by viewModel.locationResults
 
     BottomSheetDialog(
-        onDismissRequest = onDismissRequest,
-        title = {
-            Text(
-                text = stringResource(R.string.preference_location),
-            )
-        },
+        onDismissRequest = onDismissRequest
     ) {
         var query by remember { mutableStateOf("") }
         Column(

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/component/BottomSheetDialog.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/component/BottomSheetDialog.kt
@@ -34,13 +34,16 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.CornerSize
+import androidx.compose.material.ModalBottomSheetState
 import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.LocalAbsoluteTonalElevation
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
@@ -69,6 +72,7 @@ import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.PopupPositionProvider
 import de.mm20.launcher2.ui.ktx.toPixels
+import de.mm20.launcher2.ui.launcher.gestures.LauncherGestureHandler
 import de.mm20.launcher2.ui.overlays.LocalZIndex
 import de.mm20.launcher2.ui.overlays.Overlay
 import kotlinx.coroutines.launch
@@ -83,13 +87,6 @@ fun BottomSheetDialog(
     dismissButton: @Composable (() -> Unit)? = null,
     content: @Composable (paddingValues: PaddingValues) -> Unit,
 ) {
-    val scope = rememberCoroutineScope()
-
-    val focusManager = LocalFocusManager.current
-    LaunchedEffect(Unit) {
-        focusManager.clearFocus(true)
-    }
-
     ModalBottomSheet(
         onDismissRequest,
         modifier = Modifier.padding()

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/component/BottomSheetDialog.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/component/BottomSheetDialog.kt
@@ -1,279 +1,42 @@
 package de.mm20.launcher2.ui.component
 
-import android.util.Log
-import androidx.activity.compose.BackHandler
-import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.animation.core.exponentialDecay
-import androidx.compose.animation.core.spring
-import androidx.compose.foundation.background
-import androidx.compose.foundation.gestures.AnchoredDraggableState
-import androidx.compose.foundation.gestures.DraggableAnchors
-import androidx.compose.foundation.gestures.Orientation
-import androidx.compose.foundation.gestures.anchoredDraggable
-import androidx.compose.foundation.gestures.animateTo
-import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxWithConstraints
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.RowScope
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.imePadding
-import androidx.compose.foundation.layout.navigationBarsPadding
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.systemBarsPadding
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.windowInsetsPadding
-import androidx.compose.foundation.layout.wrapContentHeight
-import androidx.compose.foundation.shape.CornerSize
-import androidx.compose.material.ModalBottomSheetState
-import androidx.compose.material3.BottomSheetDefaults
-import androidx.compose.material3.CenterAlignedTopAppBar
-import androidx.compose.material3.LocalAbsoluteTonalElevation
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.SheetState
-import androidx.compose.material3.Surface
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clipToBounds
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
-import androidx.compose.ui.input.nestedscroll.NestedScrollSource
-import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.layout.onSizeChanged
-import androidx.compose.ui.platform.LocalFocusManager
-import androidx.compose.ui.unit.Density
-import androidx.compose.ui.unit.IntOffset
-import androidx.compose.ui.unit.IntRect
-import androidx.compose.ui.unit.IntSize
-import androidx.compose.ui.unit.LayoutDirection
-import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.PopupPositionProvider
-import de.mm20.launcher2.ui.ktx.toPixels
-import de.mm20.launcher2.ui.launcher.gestures.LauncherGestureHandler
-import de.mm20.launcher2.ui.overlays.LocalZIndex
-import de.mm20.launcher2.ui.overlays.Overlay
-import kotlinx.coroutines.launch
-import kotlin.math.min
-import kotlin.math.roundToInt
 
 @Composable
 fun BottomSheetDialog(
     onDismissRequest: () -> Unit,
-    actions: (@Composable RowScope.() -> Unit)? = null,
-    confirmButton: @Composable (() -> Unit)? = null,
-    dismissButton: @Composable (() -> Unit)? = null,
+    footerItems: @Composable (() -> Unit)? = null,
+    bottomSheetState: SheetState = rememberModalBottomSheetState(),
     content: @Composable (paddingValues: PaddingValues) -> Unit,
 ) {
     ModalBottomSheet(
-        onDismissRequest,
-        modifier = Modifier.padding()
+        sheetState = bottomSheetState,
+        onDismissRequest = onDismissRequest,
     ) {
         content(PaddingValues(horizontal = 24.dp, vertical = 8.dp))
-        if (confirmButton != null || dismissButton != null) {
+        if (footerItems != null) {
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(PaddingValues(horizontal = 24.dp, vertical = 8.dp)),
-                horizontalArrangement = Arrangement.End
+                    .padding(start = 24.dp, end = 24.dp, bottom = 8.dp),
+                horizontalArrangement = Arrangement.spacedBy(
+                    space = 16.dp,
+                    alignment = Alignment.End,
+                )
             ) {
-                if (dismissButton != null) {
-                    dismissButton()
-                }
-                if (confirmButton != null && dismissButton != null) {
-                    Spacer(modifier = Modifier.width(16.dp))
-                }
-                if (confirmButton != null) {
-                    confirmButton()
-                }
+                footerItems()
             }
         }
-    }
-    /*CompositionLocalProvider(
-        LocalAbsoluteTonalElevation provides 0.dp,
-    ) {
-        Overlay(zIndex = zIndex) {
-            BoxWithConstraints(
-                modifier = Modifier.fillMaxSize(),
-                propagateMinConstraints = true,
-                contentAlignment = Alignment.BottomCenter
-            ) {
-                val maxHeight = maxHeight
-                val scrimAlpha by animateFloatAsState(
-                    if (draggableState.targetValue == SwipeState.Dismiss) 0f else 0.32f,
-                    label = "Scrim alpha"
-                )
-
-                Box(modifier = Modifier
-                    .background(MaterialTheme.colorScheme.scrim.copy(alpha = scrimAlpha))
-                    .fillMaxSize()
-                    .pointerInput(onDismissRequest, dismissible) {
-                        detectTapGestures {
-                            if (dismissible()) {
-                                scope.launch {
-                                    draggableState.animateTo(SwipeState.Dismiss)
-                                    onDismissRequest()
-                                }
-                            }
-                        }
-                    }
-                )
-
-                Box(
-                    modifier = Modifier.fillMaxSize(),
-                    contentAlignment = Alignment.TopCenter,
-                ) {
-                    var sheetHeight by remember {
-                        mutableStateOf(0f)
-                    }
-
-                    val maxHeightPx = maxHeight.toPixels()
-                    LaunchedEffect(maxHeightPx, sheetHeight) {
-                        val oldValue = draggableState.currentValue
-                        val hasPeekAnchor = sheetHeight > 0f
-                        val hasFullAnchor = sheetHeight > maxHeightPx * 0.5f
-                        // If the sheet was hidden, move it to peek. Otherwise, try to keep the previous state, if possible.
-                        val newValue = when {
-                            oldValue == SwipeState.Dismiss && hasPeekAnchor -> SwipeState.Peek
-                            oldValue == SwipeState.Peek && hasPeekAnchor -> SwipeState.Peek
-                            oldValue == SwipeState.Full && hasFullAnchor -> SwipeState.Full
-                            oldValue == SwipeState.Full && hasPeekAnchor -> SwipeState.Peek
-                            else -> SwipeState.Dismiss
-                        }
-                        val newAnchors = DraggableAnchors {
-                            SwipeState.Dismiss at 0f
-                            if (hasPeekAnchor) SwipeState.Peek at -min(
-                                maxHeightPx * 0.5f,
-                                sheetHeight
-                            )
-                            if (hasFullAnchor) SwipeState.Full at -min(maxHeightPx, sheetHeight)
-                        }
-                        draggableState.updateAnchors(
-                            newAnchors,
-                            with(draggableState) {
-                                (if (!offset.isNaN()) {
-                                    newAnchors.closestAnchor(offset) ?: targetValue
-                                } else targetValue).let {
-                                    if (it == SwipeState.Dismiss && targetValue != SwipeState.Dismiss && hasPeekAnchor) SwipeState.Peek else it
-                                }
-                            },
-                        )
-                        if (newValue != oldValue) {
-                            draggableState.animateTo(newValue)
-                        }
-                    }
-                    Surface(
-                        modifier = Modifier
-                            .nestedScroll(nestedScrollConnection)
-                            .onSizeChanged {
-                                sheetHeight = it.height.toFloat()
-                            }
-                            .offset {
-                                IntOffset(0,
-                                    maxHeightPx.toInt() +
-                                            (draggableState.offset
-                                                .takeIf { !it.isNaN() }
-                                                ?.roundToInt() ?: 0)
-                                )
-                            }
-                            .anchoredDraggable(
-                                state = draggableState,
-                                orientation = Orientation.Vertical,
-                            )
-                            .fillMaxWidth(),
-                        shape = MaterialTheme.shapes.extraLarge.copy(
-                            bottomStart = CornerSize(0),
-                            bottomEnd = CornerSize(0),
-                        ),
-                        shadowElevation = 16.dp,
-                        tonalElevation = 1.dp,
-                        color = MaterialTheme.colorScheme.surfaceContainerLow,
-                    ) {
-                        Box(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .systemBarsPadding()
-                        ) {
-                            Column {
-                                if (title != null || actions != null) {
-                                    CenterAlignedTopAppBar(
-                                        title = title ?: { BottomSheetDefaults.DragHandle() },
-                                        actions = actions ?: {},
-                                        colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
-                                            containerColor = Color.Transparent,
-                                        ),
-                                    )
-                                } else {
-                                    Box(
-                                        modifier = Modifier.align(Alignment.CenterHorizontally)
-                                    ) {
-                                        BottomSheetDefaults.DragHandle()
-                                    }
-                                }
-                                Box(
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .then(
-                                            if (confirmButton != null || dismissButton != null) Modifier.padding(
-                                                bottom = 64.dp
-                                            ) else Modifier
-                                        )
-                                        .wrapContentHeight(),
-                                    propagateMinConstraints = true,
-                                    contentAlignment = Alignment.Center
-                                ) {
-                                    content(PaddingValues(horizontal = 24.dp, vertical = 8.dp))
-                                }
-
-
-
-                            }
-                        }
-                    }
-
-                }
-            }
-        }
-    }*/
-}
-
-private enum class SwipeState {
-    Full, Peek, Dismiss
-}
-
-private class BottomSheetPositionProvider(val insets: WindowInsets, val density: Density) :
-    PopupPositionProvider {
-    override fun calculatePosition(
-        anchorBounds: IntRect,
-        windowSize: IntSize,
-        layoutDirection: LayoutDirection,
-        popupContentSize: IntSize
-    ): IntOffset {
-        return IntOffset.Zero + IntOffset(
-            insets.getLeft(density, layoutDirection),
-            insets.getTop(density)
-        )
     }
 }

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/sheets/ConfigureWidgetSheet.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/sheets/ConfigureWidgetSheet.kt
@@ -106,17 +106,7 @@ fun ConfigureWidgetSheet(
     onWidgetUpdated: (Widget) -> Unit,
     onDismiss: () -> Unit,
 ) {
-    BottomSheetDialog(onDismissRequest = onDismiss,
-        title = {
-            Box(
-                modifier = Modifier
-                    .width(32.dp)
-                    .height(4.dp)
-                    .clip(MaterialTheme.shapes.small)
-                    .background(MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f))
-            )
-        }
-    ) {
+    BottomSheetDialog(onDismissRequest = onDismiss) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/sheets/CustomizeSearchableSheet.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/sheets/CustomizeSearchableSheet.kt
@@ -12,15 +12,16 @@ import androidx.compose.material.icons.rounded.Edit
 import androidx.compose.material.icons.rounded.Tag
 import androidx.compose.material.icons.rounded.Visibility
 import androidx.compose.material.icons.rounded.VisibilityOff
-import androidx.compose.material3.Button
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -28,6 +29,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -49,236 +51,238 @@ import de.mm20.launcher2.ui.component.OutlinedTagsInputField
 import de.mm20.launcher2.ui.component.ShapedLauncherIcon
 import de.mm20.launcher2.ui.ktx.toPixels
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 
 @Composable
 fun CustomizeSearchableSheet(
     searchable: SavableSearchable,
     onDismiss: () -> Unit,
 ) {
+    val scope = rememberCoroutineScope()
     val viewModel: CustomizeSearchableSheetVM =
         remember(searchable.key) { CustomizeSearchableSheetVM(searchable) }
 
     val pickIcon by viewModel.isIconPickerOpen
 
-    BottomSheetDialog(
-        onDismissRequest = onDismiss,
-        dismissButton = {
-            if (pickIcon) {
-                Button(onClick = { viewModel.closeIconPicker() }) {
-                    Text(text = stringResource(android.R.string.cancel))
+    BottomSheetDialog(onDismissRequest = { if (!pickIcon) onDismiss() }) {
+        Column(
+            modifier = Modifier.padding(it),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            val iconSize = 64.dp
+            val iconSizePx = iconSize.toPixels()
+            val icon by remember { viewModel.getIcon(iconSizePx.toInt()) }.collectAsState(null)
+
+            ShapedLauncherIcon(
+                size = iconSize,
+                icon = { icon },
+                badge = {
+                    Badge(
+                        icon = BadgeIcon(Icons.Rounded.Edit)
+                    )
+                },
+                modifier = Modifier.clickable {
+                    viewModel.openIconPicker()
                 }
+            )
+
+            var customLabelValue by remember {
+                mutableStateOf(searchable.labelOverride ?: "")
             }
-        }) {
-        if (!pickIcon) {
-            Column(
-                modifier = Modifier.padding(it),
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
-
-                val iconSize = 64.dp
-                val iconSizePx = iconSize.toPixels()
-                val icon by remember { viewModel.getIcon(iconSizePx.toInt()) }.collectAsState(null)
-
-                ShapedLauncherIcon(
-                    size = iconSize,
-                    icon = { icon },
-                    badge = {
-                        Badge(
-                            icon = BadgeIcon(Icons.Rounded.Edit)
-                        )
-                    },
-                    modifier = Modifier.clickable {
-                        viewModel.openIconPicker()
-                    }
-                )
-
-                var customLabelValue by remember {
-                    mutableStateOf(searchable.labelOverride ?: "")
+            OutlinedTextField(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 24.dp, bottom = 16.dp),
+                value = customLabelValue,
+                onValueChange = {
+                    customLabelValue = it
+                },
+                singleLine = true,
+                label = {
+                    Text(stringResource(R.string.customize_item_label))
+                },
+                placeholder = {
+                    Text(searchable.label)
+                },
+                leadingIcon = {
+                    Icon(Icons.AutoMirrored.Rounded.Label, null)
                 }
+            )
+
+            var tags by remember { mutableStateOf(emptyList<String>()) }
+            var visibility by remember { mutableStateOf(VisibilityLevel.Default) }
+
+            LaunchedEffect(searchable.key) {
+                visibility = viewModel.getVisibility().first()
+                tags = viewModel.getTags().first()
+            }
+
+            OutlinedTagsInputField(
+                modifier = Modifier
+                    .padding(top = 8.dp)
+                    .fillMaxWidth(),
+                tags = tags, onTagsChange = { tags = it.distinct() },
+                label = {
+                    Text(stringResource(R.string.customize_item_tags))
+                },
+                onAutocomplete = {
+                    viewModel.autocompleteTags(it).minus(tags.toSet())
+                },
+                leadingIcon = {
+                    Icon(Icons.Rounded.Tag, null)
+                }
+            )
+
+            var showDropdown by remember {
+                mutableStateOf(false)
+            }
+
+            ExposedDropdownMenuBox(
+                expanded = showDropdown,
+                onExpandedChange = { showDropdown = it },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 16.dp),
+            ) {
                 OutlinedTextField(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(top = 24.dp, bottom = 16.dp),
-                    value = customLabelValue,
-                    onValueChange = {
-                        customLabelValue = it
-                    },
-                    singleLine = true,
-                    label = {
-                        Text(stringResource(R.string.customize_item_label))
-                    },
-                    placeholder = {
-                        Text(searchable.label)
-                    },
-                    leadingIcon = {
-                        Icon(Icons.AutoMirrored.Rounded.Label, null)
-                    }
-                )
-
-                var tags by remember { mutableStateOf(emptyList<String>()) }
-                var visibility by remember { mutableStateOf(VisibilityLevel.Default) }
-
-                LaunchedEffect(searchable.key) {
-                    visibility = viewModel.getVisibility().first()
-                    tags = viewModel.getTags().first()
-                }
-
-                OutlinedTagsInputField(
-                    modifier = Modifier
-                        .padding(top = 8.dp)
-                        .fillMaxWidth(),
-                    tags = tags, onTagsChange = { tags = it.distinct() },
-                    label = {
-                        Text(stringResource(R.string.customize_item_tags))
-                    },
-                    onAutocomplete = {
-                        viewModel.autocompleteTags(it).minus(tags.toSet())
-                    },
-                    leadingIcon = {
-                        Icon(Icons.Rounded.Tag, null)
-                    }
-                )
-
-                var showDropdown by remember {
-                    mutableStateOf(false)
-                }
-
-                ExposedDropdownMenuBox(
-                    expanded = showDropdown,
-                    onExpandedChange = { showDropdown = it },
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(vertical = 16.dp),
-                ) {
-                    OutlinedTextField(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .menuAnchor(MenuAnchorType.PrimaryNotEditable),
-                        value = when (visibility) {
-                            VisibilityLevel.Default -> {
-                                when (searchable) {
-                                    is Application -> stringResource(R.string.item_visibility_app_default)
-                                    is CalendarEvent -> stringResource(R.string.item_visibility_calendar_default)
-                                    else -> stringResource(R.string.item_visibility_search_only)
-                                }
+                        .menuAnchor(MenuAnchorType.PrimaryNotEditable),
+                    value = when (visibility) {
+                        VisibilityLevel.Default -> {
+                            when (searchable) {
+                                is Application -> stringResource(R.string.item_visibility_app_default)
+                                is CalendarEvent -> stringResource(R.string.item_visibility_calendar_default)
+                                else -> stringResource(R.string.item_visibility_search_only)
                             }
+                        }
 
-                            VisibilityLevel.SearchOnly -> stringResource(R.string.item_visibility_search_only)
-                            VisibilityLevel.Hidden -> stringResource(R.string.item_visibility_hidden)
-                        },
-                        label = {
-                            Text(stringResource(R.string.customize_item_visibility))
-                        },
-                        onValueChange = {},
-                        readOnly = true,
-                        singleLine = true,
-                        trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = showDropdown) },
-                        leadingIcon = {
-                            Icon(
-                                when (visibility) {
-                                    VisibilityLevel.Default -> Icons.Rounded.Visibility
-                                    VisibilityLevel.SearchOnly -> Icons.Outlined.Visibility
-                                    VisibilityLevel.Hidden -> Icons.Rounded.VisibilityOff
-                                },
-                                null
-                            )
-                        },
-                        colors = ExposedDropdownMenuDefaults.outlinedTextFieldColors(),
-                    )
-                    ExposedDropdownMenu(
-                        expanded = showDropdown,
-                        onDismissRequest = {
-                            showDropdown = false
-                        }
-                    ) {
-                        if (searchable is Application) {
-                            DropdownMenuItem(
-                                onClick = {
-                                    visibility = VisibilityLevel.Default
-                                    showDropdown = false
-                                },
-                                text = {
-                                    Text(stringResource(R.string.item_visibility_app_default))
-                                },
-                                leadingIcon = {
-                                    Icon(Icons.Rounded.Visibility, null)
-                                }
-                            )
-                        } else if (searchable is CalendarEvent) {
-                            DropdownMenuItem(
-                                onClick = {
-                                    visibility = VisibilityLevel.Default
-                                    showDropdown = false
-                                },
-                                text = {
-                                    Text(stringResource(R.string.item_visibility_calendar_default))
-                                },
-                                leadingIcon = {
-                                    Icon(Icons.Rounded.Visibility, null)
-                                }
-                            )
-                        } else {
-                            DropdownMenuItem(
-                                onClick = {
-                                    visibility = VisibilityLevel.Default
-                                    showDropdown = false
-                                },
-                                text = {
-                                    Text(stringResource(R.string.item_visibility_search_only))
-                                },
-                                leadingIcon = {
-                                    Icon(Icons.Rounded.Visibility, null)
-                                }
-                            )
-                        }
-                        if (searchable is Application || searchable is CalendarEvent) {
-                            DropdownMenuItem(
-                                onClick = {
-                                    visibility = VisibilityLevel.SearchOnly
-                                    showDropdown = false
-                                },
-                                text = {
-                                    Text(stringResource(R.string.item_visibility_search_only))
-                                },
-                                leadingIcon = {
-                                    Icon(
-                                        Icons.Outlined.Visibility,
-                                        null
-                                    )
-                                }
-                            )
-                        }
+                        VisibilityLevel.SearchOnly -> stringResource(R.string.item_visibility_search_only)
+                        VisibilityLevel.Hidden -> stringResource(R.string.item_visibility_hidden)
+                    },
+                    label = {
+                        Text(stringResource(R.string.customize_item_visibility))
+                    },
+                    onValueChange = {},
+                    readOnly = true,
+                    singleLine = true,
+                    trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = showDropdown) },
+                    leadingIcon = {
+                        Icon(
+                            when (visibility) {
+                                VisibilityLevel.Default -> Icons.Rounded.Visibility
+                                VisibilityLevel.SearchOnly -> Icons.Outlined.Visibility
+                                VisibilityLevel.Hidden -> Icons.Rounded.VisibilityOff
+                            },
+                            null
+                        )
+                    },
+                    colors = ExposedDropdownMenuDefaults.outlinedTextFieldColors(),
+                )
+                ExposedDropdownMenu(
+                    expanded = showDropdown,
+                    onDismissRequest = {
+                        showDropdown = false
+                    }
+                ) {
+                    if (searchable is Application) {
                         DropdownMenuItem(
                             onClick = {
-                                visibility = VisibilityLevel.Hidden
+                                visibility = VisibilityLevel.Default
                                 showDropdown = false
                             },
                             text = {
-                                Text(stringResource(R.string.item_visibility_hidden))
+                                Text(stringResource(R.string.item_visibility_app_default))
                             },
                             leadingIcon = {
-                                Icon(Icons.Rounded.VisibilityOff, null)
+                                Icon(Icons.Rounded.Visibility, null)
+                            }
+                        )
+                    } else if (searchable is CalendarEvent) {
+                        DropdownMenuItem(
+                            onClick = {
+                                visibility = VisibilityLevel.Default
+                                showDropdown = false
+                            },
+                            text = {
+                                Text(stringResource(R.string.item_visibility_calendar_default))
+                            },
+                            leadingIcon = {
+                                Icon(Icons.Rounded.Visibility, null)
+                            }
+                        )
+                    } else {
+                        DropdownMenuItem(
+                            onClick = {
+                                visibility = VisibilityLevel.Default
+                                showDropdown = false
+                            },
+                            text = {
+                                Text(stringResource(R.string.item_visibility_search_only))
+                            },
+                            leadingIcon = {
+                                Icon(Icons.Rounded.Visibility, null)
                             }
                         )
                     }
-                }
-
-                DisposableEffect(searchable.key) {
-                    onDispose {
-                        viewModel.setCustomLabel(customLabelValue)
-                        viewModel.setTags(tags)
-                        viewModel.setVisibility(visibility)
+                    if (searchable is Application || searchable is CalendarEvent) {
+                        DropdownMenuItem(
+                            onClick = {
+                                visibility = VisibilityLevel.SearchOnly
+                                showDropdown = false
+                            },
+                            text = {
+                                Text(stringResource(R.string.item_visibility_search_only))
+                            },
+                            leadingIcon = {
+                                Icon(
+                                    Icons.Outlined.Visibility,
+                                    null
+                                )
+                            }
+                        )
                     }
+                    DropdownMenuItem(
+                        onClick = {
+                            visibility = VisibilityLevel.Hidden
+                            showDropdown = false
+                        },
+                        text = {
+                            Text(stringResource(R.string.item_visibility_hidden))
+                        },
+                        leadingIcon = {
+                            Icon(Icons.Rounded.VisibilityOff, null)
+                        }
+                    )
                 }
             }
-        } else {
-            IconPicker(
-                searchable = searchable,
-                onSelect = {
-                    viewModel.pickIcon(it)
-                },
-                contentPadding = it,
-            )
+
+            DisposableEffect(searchable.key) {
+                onDispose {
+                    viewModel.setCustomLabel(customLabelValue)
+                    viewModel.setTags(tags)
+                    viewModel.setVisibility(visibility)
+                }
+            }
+        }
+        if (pickIcon) {
+            val bottomSheetState = rememberModalBottomSheetState()
+            ModalBottomSheet (
+                onDismissRequest = { viewModel.closeIconPicker() },
+                sheetState = bottomSheetState
+            ) {
+                IconPicker(
+                    searchable = searchable,
+                    onSelect = {
+                        scope.launch {
+                            viewModel.pickIcon(it)
+                            bottomSheetState.hide()
+                            viewModel.closeIconPicker()
+                        }
+                    },
+                    contentPadding = it,
+                )
+            }
         }
     }
 }

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/sheets/CustomizeSearchableSheet.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/sheets/CustomizeSearchableSheet.kt
@@ -1,42 +1,24 @@
 package de.mm20.launcher2.ui.launcher.sheets
 
-import android.content.pm.PackageManager
-import androidx.activity.compose.BackHandler
-import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.wrapContentWidth
-import androidx.compose.foundation.lazy.grid.GridCells
-import androidx.compose.foundation.lazy.grid.GridItemSpan
-import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.Label
 import androidx.compose.material.icons.outlined.Visibility
-import androidx.compose.material.icons.rounded.ArrowDropDown
 import androidx.compose.material.icons.rounded.Edit
-import androidx.compose.material.icons.rounded.FilterAlt
-import androidx.compose.material.icons.rounded.Search
 import androidx.compose.material.icons.rounded.Tag
 import androidx.compose.material.icons.rounded.Visibility
 import androidx.compose.material.icons.rounded.VisibilityOff
 import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MenuAnchorType
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -46,20 +28,16 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import coil.compose.AsyncImage
 import de.mm20.launcher2.badges.Badge
 import de.mm20.launcher2.badges.BadgeIcon
 import de.mm20.launcher2.icons.CustomIconWithPreview
-import de.mm20.launcher2.icons.IconPack
 import de.mm20.launcher2.search.Application
 import de.mm20.launcher2.search.CalendarEvent
 import de.mm20.launcher2.search.SavableSearchable
@@ -70,9 +48,7 @@ import de.mm20.launcher2.ui.component.BottomSheetDialog
 import de.mm20.launcher2.ui.component.OutlinedTagsInputField
 import de.mm20.launcher2.ui.component.ShapedLauncherIcon
 import de.mm20.launcher2.ui.ktx.toPixels
-import de.mm20.launcher2.ui.locals.LocalGridSettings
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.launch
 
 @Composable
 fun CustomizeSearchableSheet(
@@ -84,34 +60,18 @@ fun CustomizeSearchableSheet(
 
     val pickIcon by viewModel.isIconPickerOpen
 
-    if (pickIcon) {
-        BackHandler {
-            viewModel.closeIconPicker()
-        }
-    }
-
     BottomSheetDialog(
         onDismissRequest = onDismiss,
-        title = if (pickIcon) {
-            {
-                Text(stringResource(R.string.icon_picker_title))
-            }
-        } else null,
-        dismissible = { !pickIcon },
-        confirmButton = if (pickIcon) {
-            {
-                OutlinedButton(onClick = { viewModel.closeIconPicker() }) {
-                    Text(stringResource(id = android.R.string.cancel))
+        dismissButton = {
+            if (pickIcon) {
+                Button(onClick = { viewModel.closeIconPicker() }) {
+                    Text(text = stringResource(android.R.string.cancel))
                 }
             }
-        } else null,
-        zIndex = 100f,
-    ) {
+        }) {
         if (!pickIcon) {
             Column(
-                modifier = Modifier
-                    .padding(top = 8.dp)
-                    .padding(it),
+                modifier = Modifier.padding(it),
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
 

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/sheets/CustomizeSearchableSheet.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/sheets/CustomizeSearchableSheet.kt
@@ -267,9 +267,9 @@ fun CustomizeSearchableSheet(
         }
         if (pickIcon) {
             val bottomSheetState = rememberModalBottomSheetState()
-            ModalBottomSheet (
+            BottomSheetDialog (
                 onDismissRequest = { viewModel.closeIconPicker() },
-                sheetState = bottomSheetState
+                bottomSheetState = bottomSheetState
             ) {
                 IconPicker(
                     searchable = searchable,

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/sheets/CustomizeSearchableSheetVM.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/sheets/CustomizeSearchableSheetVM.kt
@@ -45,7 +45,6 @@ class CustomizeSearchableSheetVM(
 
     fun pickIcon(icon: CustomIcon?) {
         iconService.setCustomIcon(searchable, icon)
-        closeIconPicker()
     }
 
     fun setCustomLabel(label: String) {

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/sheets/EditFavoritesSheet.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/sheets/EditFavoritesSheet.kt
@@ -39,7 +39,6 @@ import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderDefaults
@@ -106,28 +105,7 @@ fun EditFavoritesSheet(
     val loading by viewModel.loading
     val createShortcutTarget by viewModel.createShortcutTarget
 
-    BottomSheetDialog(
-        onDismissRequest = onDismiss,
-        title = {
-            Text(
-                if (createShortcutTarget == null) {
-                    stringResource(id = R.string.menu_item_edit_favs)
-                } else {
-                    stringResource(id = R.string.create_app_shortcut)
-                }
-            )
-        },
-        dismissible = {
-            createShortcutTarget == null
-        },
-        confirmButton = if (createShortcutTarget != null) {
-            {
-                OutlinedButton(onClick = { viewModel.cancelPickShortcut() }) {
-                    Text(stringResource(id = android.R.string.cancel))
-                }
-            }
-        } else null
-    ) {
+    BottomSheetDialog(onDismiss) {
         if (loading) {
             Box(
                 modifier = Modifier

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/sheets/EditFavoritesSheetVM.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/sheets/EditFavoritesSheetVM.kt
@@ -86,6 +86,8 @@ class EditFavoritesSheetVM : ViewModel(), KoinComponent {
                 .map { Tag(it) }
         this.pinnedTags.value = pinnedTags
 
+        createShortcutTarget.value = null
+
         buildItemList()
         loading.value = false
     }

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/sheets/EditTagSheetVM.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/sheets/EditTagSheetVM.kt
@@ -20,9 +20,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.launch
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
@@ -83,7 +81,7 @@ class EditTagSheetVM : ViewModel(), KoinComponent {
         val oldName = oldTagName
         val newName = tagName
         val tagIcon = tagCustomIcon
-        if (taggedItems.isEmpty() && oldName != null) tagService.deleteTag(oldName)
+        if ((taggedItems.isEmpty() || tagName.isEmpty()) && oldName != null) tagService.deleteTag(oldName)
         else if (oldName != null) tagService.updateTag(oldName, newName = newName, items = taggedItems)
         else tagService.createTag(tagName, taggedItems)
 

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/sheets/FailedGestureSheet.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/sheets/FailedGestureSheet.kt
@@ -47,7 +47,6 @@ fun FailedGestureSheet(
     })
 
     BottomSheetDialog(
-        title = { Text(actionName) },
         onDismissRequest = onDismiss,
     ) {
         Column(

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/sheets/HiddenItemsSheet.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/sheets/HiddenItemsSheet.kt
@@ -3,14 +3,8 @@ package de.mm20.launcher2.ui.launcher.sheets
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.rounded.Edit
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
-import androidx.lifecycle.viewmodel.compose.viewModel
 import de.mm20.launcher2.search.SavableSearchable
 import de.mm20.launcher2.ui.component.BottomSheetDialog
 import de.mm20.launcher2.ui.launcher.search.common.grid.SearchResultGrid
@@ -20,18 +14,7 @@ fun HiddenItemsSheet(
     items: List<SavableSearchable>,
     onDismiss: () -> Unit
 ) {
-    val viewModel: HiddenItemsSheetVM = viewModel()
-
-    val context = LocalContext.current
-
-    BottomSheetDialog(
-        onDismissRequest = onDismiss,
-        actions = {
-            IconButton(onClick = { viewModel.showHiddenItems(context) }) {
-                Icon(imageVector = Icons.Rounded.Edit, contentDescription = null)
-            }
-        },
-    ) {
+    BottomSheetDialog(onDismiss) {
         SearchResultGrid(
             items,
             modifier = Modifier

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/sheets/HiddenItemsSheet.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/sheets/HiddenItemsSheet.kt
@@ -32,14 +32,6 @@ fun HiddenItemsSheet(
 
     BottomSheetDialog(
         onDismissRequest = onDismiss,
-        title = {
-            Text(
-                stringResource(R.string.preference_hidden_items),
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.padding(end = 16.dp),
-                maxLines = 1
-            )
-        },
         actions = {
             IconButton(onClick = { viewModel.showHiddenItems(context) }) {
                 Icon(imageVector = Icons.Rounded.Edit, contentDescription = null)

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/sheets/HiddenItemsSheet.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/sheets/HiddenItemsSheet.kt
@@ -7,17 +7,11 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Edit
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import de.mm20.launcher2.search.SavableSearchable
-import de.mm20.launcher2.ui.R
 import de.mm20.launcher2.ui.component.BottomSheetDialog
 import de.mm20.launcher2.ui.launcher.search.common.grid.SearchResultGrid
 
@@ -38,7 +32,6 @@ fun HiddenItemsSheet(
             }
         },
     ) {
-
         SearchResultGrid(
             items,
             modifier = Modifier

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/sheets/WidgetPickerSheet.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/sheets/WidgetPickerSheet.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -64,9 +65,9 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import coil.compose.AsyncImage
 import de.mm20.launcher2.ui.R
 import de.mm20.launcher2.ui.component.BottomSheetDialog
-import de.mm20.launcher2.widgets.CalendarWidget
 import de.mm20.launcher2.widgets.AppWidget
 import de.mm20.launcher2.widgets.AppWidgetConfig
+import de.mm20.launcher2.widgets.CalendarWidget
 import de.mm20.launcher2.widgets.FavoritesWidget
 import de.mm20.launcher2.widgets.MusicWidget
 import de.mm20.launcher2.widgets.NotesWidget
@@ -297,6 +298,7 @@ fun WidgetPickerSheet(
                             )
                         }
                         .padding(bottom = 16.dp, start = 16.dp, end = 16.dp),
+                    windowInsets = WindowInsets(0.dp),
                     query = query,
                     onQueryChange = { viewModel.search(it) },
                     onSearch = {},

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/sheets/WidgetPickerSheet.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/sheets/WidgetPickerSheet.kt
@@ -277,10 +277,8 @@ fun WidgetPickerSheet(
     val query by viewModel.searchQuery.collectAsState("")
 
     BottomSheetDialog(
-        onDismissRequest = onDismiss,
-        title = {
-            Text(title)
-        }) {
+        onDismissRequest = onDismiss
+    ) {
         val builtIn by viewModel.builtInWidgets.collectAsState(emptyList())
         LazyColumn(
             modifier = Modifier

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/widgets/clock/ClockWidget.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/widgets/clock/ClockWidget.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.rounded.AccessTime
 import androidx.compose.material.icons.rounded.Alarm
 import androidx.compose.material.icons.rounded.AlignVerticalBottom
@@ -370,11 +371,16 @@ fun ConfigureClockWidgetSheet(
                     icon = {
                         SegmentedButtonDefaults.Icon(
                             active = compact == false,
+                            activeContent = {
+                                Icon(
+                                    imageVector = Icons.Filled.Check,
+                                    contentDescription = null,
+                                )
+                            }
                         ) {
                             Icon(
                                 imageVector = Icons.Rounded.HorizontalSplit,
                                 contentDescription = null,
-                                modifier = Modifier.size(SegmentedButtonDefaults.IconSize)
                             )
                         }
                     }
@@ -390,11 +396,16 @@ fun ConfigureClockWidgetSheet(
                     icon = {
                         SegmentedButtonDefaults.Icon(
                             active = compact == true,
+                            activeContent = {
+                                Icon(
+                                    imageVector = Icons.Filled.Check,
+                                    contentDescription = null,
+                                )
+                            }
                         ) {
                             Icon(
                                 imageVector = Icons.Rounded.VerticalSplit,
                                 contentDescription = null,
-                                modifier = Modifier.size(SegmentedButtonDefaults.IconSize)
                             )
                         }
                     }

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/widgets/notes/NotesWidget.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/widgets/notes/NotesWidget.kt
@@ -7,9 +7,9 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -48,6 +48,7 @@ import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -57,7 +58,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.res.stringResource
@@ -398,39 +398,11 @@ fun NoteWidgetConflictResolveSheet(
     onDismissRequest: () -> Unit,
 ) {
     var selectedStrategy by remember { mutableStateOf<LinkedFileConflictStrategy?>(null) }
+    val bottomSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     BottomSheetDialog(
         onDismissRequest = onDismissRequest,
-        confirmButton = {
-            Button(
-                onClick = { onResolve(selectedStrategy ?: return@Button) },
-                enabled = selectedStrategy != null,
-                contentPadding = ButtonDefaults.ButtonWithIconContentPadding,
-            ) {
-                Icon(
-                    Icons.Rounded.CheckCircleOutline,
-                    null,
-                    modifier = Modifier
-                        .padding(end = ButtonDefaults.IconSpacing)
-                        .size(ButtonDefaults.IconSize)
-                )
-                Text(stringResource(R.string.note_widget_conflict_keep_selected))
-            }
-        },
-        dismissButton = {
-            TextButton(
-                onClick = { onResolve(LinkedFileConflictStrategy.Unlink) },
-                contentPadding = ButtonDefaults.TextButtonWithIconContentPadding,
-            ) {
-                Icon(
-                    Icons.Rounded.LinkOff,
-                    null,
-                    modifier = Modifier
-                        .padding(end = ButtonDefaults.IconSpacing)
-                        .size(ButtonDefaults.IconSize)
-                )
-                Text(stringResource(R.string.note_widget_action_unlink_file))
-            }
-        }
+        bottomSheetState = bottomSheetState
+
     ) {
         Column(
             modifier = Modifier
@@ -463,6 +435,41 @@ fun NoteWidgetConflictResolveSheet(
                 selected = selectedStrategy == LinkedFileConflictStrategy.KeepFile,
                 onSelect = { selectedStrategy = LinkedFileConflictStrategy.KeepFile },
             )
+            Row (
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 8.dp),
+                horizontalArrangement = Arrangement.End
+            ){
+                TextButton(
+                    onClick = { onResolve(LinkedFileConflictStrategy.Unlink) },
+                    contentPadding = ButtonDefaults.TextButtonWithIconContentPadding,
+                ) {
+                    Icon(
+                        Icons.Rounded.LinkOff,
+                        null,
+                        modifier = Modifier
+                            .padding(end = ButtonDefaults.IconSpacing)
+                            .size(ButtonDefaults.IconSize)
+                    )
+                    Text(stringResource(R.string.note_widget_action_unlink_file))
+                }
+                Spacer(modifier = Modifier.padding(8.dp))
+                Button(
+                    onClick = { onResolve(selectedStrategy ?: return@Button) },
+                    enabled = selectedStrategy != null,
+                    contentPadding = ButtonDefaults.ButtonWithIconContentPadding,
+                ) {
+                    Icon(
+                        Icons.Rounded.CheckCircleOutline,
+                        null,
+                        modifier = Modifier
+                            .padding(end = ButtonDefaults.IconSpacing)
+                            .size(ButtonDefaults.IconSize)
+                    )
+                    Text(stringResource(R.string.note_widget_conflict_keep_selected))
+                }
+            }
         }
     }
 }
@@ -504,21 +511,6 @@ fun SelectableNoteContent(
                     .padding(16.dp),
                 text = content, onTextChange = {}
             )
-            if (!expanded) {
-                Canvas(
-                    modifier = Modifier
-                        .height(32.dp)
-                        .fillMaxWidth()
-                        .align(Alignment.BottomCenter)
-                ) {
-                    drawRect(
-                        brush = Brush.verticalGradient(
-                            0f to color.copy(alpha = 0f),
-                            1f to color.copy(alpha = 0.8f),
-                        ),
-                    )
-                }
-            }
             IconButton(
                 modifier = Modifier.align(Alignment.TopEnd),
                 onClick = onSelect

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/settings/backup/CreateBackupSheet.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/settings/backup/CreateBackupSheet.kt
@@ -52,11 +52,6 @@ fun CreateBackupSheet(
 
     BottomSheetDialog(
         onDismissRequest = onDismissRequest,
-        title = {
-            Text(
-                stringResource(id = R.string.preference_backup),
-            )
-        },
         confirmButton = {
             if (state == CreateBackupState.Ready) {
                 Button(

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/settings/backup/CreateBackupSheet.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/settings/backup/CreateBackupSheet.kt
@@ -2,26 +2,24 @@ package de.mm20.launcher2.ui.settings.backup
 
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.rounded.*
-import androidx.compose.material3.*
+import androidx.compose.material.icons.rounded.CheckCircleOutline
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import de.mm20.launcher2.ui.R
 import de.mm20.launcher2.ui.component.BottomSheetDialog
 import de.mm20.launcher2.ui.component.LargeMessage
-import de.mm20.launcher2.ui.component.SmallMessage
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 
@@ -50,62 +48,28 @@ fun CreateBackupSheet(
 
     val state by viewModel.state
 
-    BottomSheetDialog(
-        onDismissRequest = onDismissRequest,
-        confirmButton = {
-            if (state == CreateBackupState.Ready) {
-                Button(
-                    onClick = {
-                        val fileName = "${
-                            ZonedDateTime.now().format(
-                                DateTimeFormatter.ISO_INSTANT
-                            )
-                        }.kvaesitso"
-                        backupLauncher.launch(fileName)
-                    }) {
-                    Text(stringResource(R.string.preference_backup))
-                }
-            } else if (state == CreateBackupState.BackedUp) {
-                OutlinedButton(
-                    onClick = onDismissRequest
+    if (state == CreateBackupState.BackingUp || state == CreateBackupState.BackedUp) {
+        BottomSheetDialog(onDismissRequest) {
+            if (state == CreateBackupState.BackingUp) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .aspectRatio(1f),
+                    contentAlignment = Alignment.Center
                 ) {
-                    Text(stringResource(R.string.close))
-                }
-            }
-        },
-    ) {
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .wrapContentHeight()
-                .verticalScroll(rememberScrollState())
-                .padding(it)
-        ) {
-            when (state) {
-                CreateBackupState.Ready -> {
-
-                }
-                CreateBackupState.BackingUp -> {
-                    Box(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .aspectRatio(1f),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        CircularProgressIndicator(
-                            modifier = Modifier.size(48.dp)
-                        )
-                    }
-                }
-                CreateBackupState.BackedUp -> {
-                    LargeMessage(
-                        modifier = Modifier.aspectRatio(1f),
-                        icon = Icons.Rounded.CheckCircleOutline,
-                        text = stringResource(
-                            id = R.string.backup_complete
-                        )
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(48.dp)
                     )
                 }
+            }
+            else {
+                LargeMessage(
+                    modifier = Modifier.aspectRatio(1f),
+                    icon = Icons.Rounded.CheckCircleOutline,
+                    text = stringResource(
+                        id = R.string.backup_complete
+                    )
+                )
             }
         }
     }

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/settings/gestures/GestureSettingsScreen.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/settings/gestures/GestureSettingsScreen.kt
@@ -279,7 +279,6 @@ fun GesturePreference(
 
     if (!isOpenSearch && value is GestureAction.Launch && (showAppPicker || app == null)) {
         SearchablePicker(
-            title = { Text(title) },
             onDismissRequest = {
                 showAppPicker = false
                 if (app == null) onValueChanged(GestureAction.NoAction)

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/settings/searchactions/EditSearchActionSheet.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/settings/searchactions/EditSearchActionSheet.kt
@@ -114,9 +114,6 @@ fun EditSearchActionSheet(
             viewModel.onDismiss()
             onDismiss()
         },
-        dismissible = {
-            page != EditSearchActionPage.PickIcon
-        },
         confirmButton = when (page) {
             EditSearchActionPage.CustomizeAppSearch,
             EditSearchActionPage.CustomizeWebSearch,
@@ -190,17 +187,6 @@ fun EditSearchActionSheet(
                     }
                 }
             }
-        },
-        title = {
-            Text(
-                stringResource(
-                    if (createNew) {
-                        R.string.create_search_action_title
-                    } else {
-                        R.string.edit_search_action_title
-                    }
-                )
-            )
         }) {
         when (page) {
             EditSearchActionPage.SelectType -> SelectTypePage(viewModel, it)

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/settings/searchactions/EditSearchActionSheet.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/settings/searchactions/EditSearchActionSheet.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -56,7 +57,6 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -85,8 +85,8 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import de.mm20.launcher2.searchactions.actions.SearchActionIcon
 import de.mm20.launcher2.searchactions.builders.AppSearchActionBuilder
 import de.mm20.launcher2.searchactions.builders.CustomIntentActionBuilder
-import de.mm20.launcher2.searchactions.builders.CustomizableSearchActionBuilder
 import de.mm20.launcher2.searchactions.builders.CustomWebsearchActionBuilder
+import de.mm20.launcher2.searchactions.builders.CustomizableSearchActionBuilder
 import de.mm20.launcher2.ui.R
 import de.mm20.launcher2.ui.component.BottomSheetDialog
 import de.mm20.launcher2.ui.component.ExperimentalBadge
@@ -114,11 +114,22 @@ fun EditSearchActionSheet(
             viewModel.onDismiss()
             onDismiss()
         },
-        confirmButton = when (page) {
+        footerItems = when (page) {
             EditSearchActionPage.CustomizeAppSearch,
             EditSearchActionPage.CustomizeWebSearch,
             EditSearchActionPage.CustomizeCustomIntent -> {
                 {
+                    if (!createNew) {
+                        OutlinedButton(
+                            onClick = { onDelete() },
+                            colors = ButtonDefaults.outlinedButtonColors(
+                                contentColor = MaterialTheme.colorScheme.error
+                            )
+                        ) {
+                            Text(stringResource(R.string.menu_delete))
+                        }
+                    }
+
                     Button(onClick = {
                         if (viewModel.validate()) {
                             viewModel.onSave()
@@ -167,26 +178,6 @@ fun EditSearchActionSheet(
             }
 
             else -> null
-        },
-        actions = {
-            var showMenu by remember { mutableStateOf(false) }
-            if (!createNew) {
-                IconButton(onClick = { showMenu = !showMenu }) {
-                    Icon(imageVector = Icons.Rounded.MoreVert, contentDescription = null)
-                    DropdownMenu(expanded = showMenu, onDismissRequest = { showMenu = false }) {
-                        DropdownMenuItem(
-                            text = { Text(stringResource(id = R.string.menu_delete)) },
-                            leadingIcon = {
-                                Icon(imageVector = Icons.Rounded.Delete, contentDescription = null)
-                            },
-                            onClick = {
-                                onDelete()
-                                showMenu = false
-                            }
-                        )
-                    }
-                }
-            }
         }) {
         when (page) {
             EditSearchActionPage.SelectType -> SelectTypePage(viewModel, it)
@@ -727,7 +718,7 @@ fun PickIcon(viewModel: EditSearchActionSheetVM, paddingValues: PaddingValues) {
     if (action?.customIcon == null) {
 
         val availableIcons =
-            remember { SearchActionIcon.values().filter { it != SearchActionIcon.Custom } }
+            remember { SearchActionIcon.entries.filter { it != SearchActionIcon.Custom } }
 
         Column(
             modifier = Modifier.padding(paddingValues)
@@ -773,7 +764,7 @@ fun PickIcon(viewModel: EditSearchActionSheetVM, paddingValues: PaddingValues) {
                 }
             }
             TextButton(
-                modifier = Modifier.padding(top = 16.dp, bottom = 24.dp),
+                modifier = Modifier.padding(vertical = 8.dp),
                 onClick = { pickIconLauncher.launch("image/*") }) {
                 Text(stringResource(R.string.websearch_dialog_custom_icon))
             }
@@ -781,7 +772,8 @@ fun PickIcon(viewModel: EditSearchActionSheetVM, paddingValues: PaddingValues) {
     } else {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
-            modifier = Modifier.padding(paddingValues)
+            modifier = Modifier.padding(paddingValues).fillMaxWidth()
+
         ) {
             SearchActionIconTile {
                 SearchActionIcon(builder = action!!, size = 24.dp)
@@ -803,15 +795,17 @@ fun PickIcon(viewModel: EditSearchActionSheetVM, paddingValues: PaddingValues) {
             Row(
                 modifier = Modifier
                     .padding(top = 24.dp)
-                    .horizontalScroll(rememberScrollState())
+                    .horizontalScroll(rememberScrollState()),
+                horizontalArrangement = Arrangement.spacedBy(
+                    space = 16.dp,
+                    alignment = Alignment.End
+                )
             ) {
                 OutlinedButton(
-                    modifier = Modifier.padding(start = 16.dp),
                     onClick = { pickIconLauncher.launch("image/*") }) {
                     Text(stringResource(R.string.websearch_dialog_replace_icon))
                 }
                 OutlinedButton(
-                    modifier = Modifier.padding(start = 16.dp),
                     onClick = { viewModel.setIcon(SearchActionIcon.Search) },
                     colors = ButtonDefaults.outlinedButtonColors(
                         contentColor = MaterialTheme.colorScheme.error

--- a/core/i18n/src/main/res/values/strings.xml
+++ b/core/i18n/src/main/res/values/strings.xml
@@ -732,6 +732,7 @@
     <string name="tag_exists_error">A tag with this name already exists.</string>
     <string name="tag_exists_message">A tag with this name already exists. If you continue, the two tags will be merged.</string>
     <string name="tag_no_items_message">No items are assigned to this tag. If you continue, the tag will be deleted.</string>
+    <string name="tag_empty_name">A tag cannot exist without a name. If you continue, the tag will be deleted.</string>
     <string name="tag_select_items">Select items:</string>
     <string name="tag_name">Tag name</string>
     <plurals name="tag_selected_items">


### PR DESCRIPTION
Greetings, I wanted to fix the bug where the bottom sheet doesn't display under the navigation bar, but got carried away and kinda moved all bottom sheets to the standard ones from compose material3 lib.

This also unintentionally fixed a bunch of other issues:
```

- Fix a small transparent gap between keyboard and sheet
- Fix needing to swipe very fast to expand the sheet
- Fix sheet sometimes blocking user from exiting
- Fixed a lot of button misalignments

Tag edit scaffold:
- Fix edit tag text box not having a label
- Stop user from creating nameless tags


App edit scaffold:
- Icon selection now opens in a separate sheet and that brings transition animations between the menus.

Icon edit scaffold:
- Hide search bar when no icon packs installed
- Hide "Suggestions" tag when there are no suggestions

Weather location scaffold:
- The search bar is now an actual search bar instead of a regular text field

Clock widget edit scaffold:
- Icons on the buttons now match the text size
```

Unfortunately two minor things did not survive this refactor:
- Sheet names. I doubt this is a big issue as the user pretty much always knows why the sheet opened, however it's worth noting.
- Top actions. I moved them to regular buttons where it made sense.

Although I tried to test as thoroughly as I could, I expect there to be something I missed, so all testing efforts will be appreciated.