### PR TITLE
Widget editor fixes + force resize widgets

### DIFF
--- a/app/ui/src/main/java/de/mm20/launcher2/ui/component/DragResizeHandle.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/component/DragResizeHandle.kt
@@ -69,6 +69,9 @@ fun DragResizeHandle(
         val measuredWidth = this.maxWidth
         val measuredHeight = this.maxHeight
 
+        val actualMaxWidth = if (maxWidth == Dp.Unspecified) measuredWidth else min(measuredWidth, maxWidth)
+        val actualMaxHeight = if (maxHeight == Dp.Unspecified) measuredHeight else min(measuredHeight, maxHeight)
+
         var dragging by remember { mutableStateOf(false) }
 
         val density = LocalDensity.current
@@ -93,27 +96,32 @@ fun DragResizeHandle(
 
                     val newWidth = (currentWidth + with(density) { dragDelta.toDp() }).coerceIn(
                         minWidth,
-                        maxWidth
+                        actualMaxWidth
                     )
 
                     if (snapToMeasuredWidth &&
-                        maxWidth >= measuredWidth &&
-                        newWidth > measuredWidth - 16.dp &&
+                        newWidth > actualMaxWidth - 16.dp &&
+                        width < actualMaxWidth &&
                         dragDelta > 0
                     ) {
-                        if (!width.isUnspecified) {
-                            hapticFeedback.performHapticFeedback(HapticFeedbackType.TextHandleMove)
-                            onResize(Dp.Unspecified, height)
-                        }
+                        hapticFeedback.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                        onResize(actualMaxWidth, height)
+                    } else if (
+                        snapToMeasuredWidth &&
+                        newWidth <= minWidth + 16.dp &&
+                        width > minWidth &&
+                        dragDelta < 0
+                    ) {
+                        hapticFeedback.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                        onResize(minWidth, height)
                     } else {
                         onResize(newWidth, height)
                     }
-
                 }
                 Box(
                     Modifier
                         .align(Alignment.CenterEnd)
-                        .offset(x = min(256.dp, width) / 2)
+                        .offset(x = min(128.dp, width) / 2)
                         .draggable(
                             state = horizontalDragState,
                             orientation = Orientation.Horizontal,
@@ -126,7 +134,7 @@ fun DragResizeHandle(
                             },
                             startDragImmediately = true,
                         )
-                        .requiredSize(width = min(256.dp, width), height = measuredHeight)
+                        .requiredSize(width = min(128.dp, width), height = height)
                 ) {
                     Icon(
                         modifier = Modifier
@@ -151,18 +159,24 @@ fun DragResizeHandle(
                         }
                     val newHeight = (currentHeight + with(density) { dragDelta.toDp() }).coerceIn(
                         minHeight,
-                        maxHeight
+                        actualMaxHeight
                     )
 
                     if (snapToMeasuredHeight &&
-                        maxHeight >= measuredHeight &&
-                        newHeight > measuredHeight - 16.dp &&
+                        newHeight > actualMaxHeight - 16.dp &&
+                        height < actualMaxHeight &&
                         dragDelta > 0
                     ) {
-                        if (!height.isUnspecified) {
-                            hapticFeedback.performHapticFeedback(HapticFeedbackType.TextHandleMove)
-                            onResize(width, Dp.Unspecified)
-                        }
+                        hapticFeedback.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                        onResize(width, actualMaxHeight)
+                    } else if (
+                        snapToMeasuredHeight &&
+                        newHeight <= minHeight + 16.dp &&
+                        height > minHeight &&
+                        dragDelta < 0
+                    ) {
+                        hapticFeedback.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                        onResize(width, minHeight)
                     } else {
                         onResize(width, newHeight)
                     }
@@ -183,7 +197,7 @@ fun DragResizeHandle(
                             },
                             startDragImmediately = true,
                         )
-                        .requiredSize(height = min(64.dp, height), width = measuredWidth)
+                        .requiredSize(height = min(64.dp, height), width = width)
                 ) {
                     Icon(
                         modifier = Modifier

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/component/DragResizeHandle.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/component/DragResizeHandle.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.coerceIn
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.isUnspecified
+import androidx.compose.ui.unit.min
 
 enum class ResizeAxis {
     Horizontal,
@@ -112,7 +113,7 @@ fun DragResizeHandle(
                 Box(
                     Modifier
                         .align(Alignment.CenterEnd)
-                        .offset(x = 128.dp)
+                        .offset(x = min(256.dp, width) / 2)
                         .draggable(
                             state = horizontalDragState,
                             orientation = Orientation.Horizontal,
@@ -125,7 +126,7 @@ fun DragResizeHandle(
                             },
                             startDragImmediately = true,
                         )
-                        .requiredSize(width = 256.dp, height = measuredHeight)
+                        .requiredSize(width = min(256.dp, width), height = measuredHeight)
                 ) {
                     Icon(
                         modifier = Modifier
@@ -169,7 +170,7 @@ fun DragResizeHandle(
                 Box(
                     Modifier
                         .align(Alignment.BottomCenter)
-                        .offset(y = 32.dp)
+                        .offset(y = min(64.dp, height) / 2)
                         .draggable(
                             state = verticalDragState,
                             orientation = Orientation.Vertical,
@@ -182,7 +183,7 @@ fun DragResizeHandle(
                             },
                             startDragImmediately = true,
                         )
-                        .requiredSize(height = 64.dp, width = measuredWidth)
+                        .requiredSize(height = min(64.dp, height), width = measuredWidth)
                 ) {
                     Icon(
                         modifier = Modifier

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/component/DragResizeHandle.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/component/DragResizeHandle.kt
@@ -16,9 +16,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.requiredHeight
 import androidx.compose.foundation.layout.requiredSize
-import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
@@ -114,7 +112,7 @@ fun DragResizeHandle(
                 Box(
                     Modifier
                         .align(Alignment.CenterEnd)
-                        .offset(x = 64.dp)
+                        .offset(x = 128.dp)
                         .draggable(
                             state = horizontalDragState,
                             orientation = Orientation.Horizontal,
@@ -127,7 +125,7 @@ fun DragResizeHandle(
                             },
                             startDragImmediately = true,
                         )
-                        .requiredSize(128.dp)
+                        .requiredSize(width = 256.dp, height = measuredHeight)
                 ) {
                     Icon(
                         modifier = Modifier
@@ -171,7 +169,7 @@ fun DragResizeHandle(
                 Box(
                     Modifier
                         .align(Alignment.BottomCenter)
-                        .offset(y = 64.dp)
+                        .offset(y = 32.dp)
                         .draggable(
                             state = verticalDragState,
                             orientation = Orientation.Vertical,
@@ -184,7 +182,7 @@ fun DragResizeHandle(
                             },
                             startDragImmediately = true,
                         )
-                        .requiredSize(128.dp)
+                        .requiredSize(height = 64.dp, width = measuredWidth)
                 ) {
                     Icon(
                         modifier = Modifier

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/sheets/ConfigureWidgetSheet.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/sheets/ConfigureWidgetSheet.kt
@@ -7,6 +7,7 @@ import android.appwidget.AppWidgetProviderInfo
 import android.content.Intent
 import android.net.Uri
 import android.os.Build
+import android.util.Log
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
@@ -380,11 +381,11 @@ fun ColumnScope.ConfigureAppWidget(
                 onLightBackground = (!LocalDarkTheme.current && widget.config.background) || LocalPreferDarkContentOverWallpaper.current
             )
 
-            val maxWidth = if (isAtLeastApiLevel(31) && !widget.config.forceResize) {
+            val maxWidth = if (isAtLeastApiLevel(31)) {
                 widgetInfo.maxResizeWidth.takeIf { it > 0 }?.toDp() ?: Dp.Unspecified
             } else Dp.Unspecified
 
-            val maxHeight = if (isAtLeastApiLevel(31) && !widget.config.forceResize) {
+            val maxHeight = if (isAtLeastApiLevel(31)) {
                 widgetInfo.maxResizeHeight.takeIf { it > 0 }?.toDp() ?: 2000.dp
             } else 2000.dp
 
@@ -418,6 +419,7 @@ fun ColumnScope.ConfigureAppWidget(
                 onResize = { w, h ->
                     resizeWidth = w
                     resizeHeight = h
+                    Log.e("resizeWidth", resizeWidth.toString())
                 },
                 onResizeStopped = {
                     onWidgetUpdated(

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/sheets/ConfigureWidgetSheet.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/sheets/ConfigureWidgetSheet.kt
@@ -388,15 +388,13 @@ fun ColumnScope.ConfigureAppWidget(
                 widgetInfo.maxResizeHeight.takeIf { it > 0 }?.toDp() ?: 2000.dp
             } else 2000.dp
 
-            val minWidth = if (widget.config.forceResize) 20.dp
-            else if (widgetInfo.minResizeWidth in 1..widgetInfo.minWidth) {
+            val minWidth = if (widgetInfo.minResizeWidth in 1..widgetInfo.minWidth) {
                 widgetInfo.minResizeWidth.toDp()
             } else {
                 widgetInfo.minWidth.toDp()
             }
 
-            val minHeight = if (widget.config.forceResize) 20.dp
-            else if (widgetInfo.minResizeHeight in 1..widgetInfo.minHeight) {
+            val minHeight = if (widgetInfo.minResizeHeight in 1..widgetInfo.minHeight) {
                 widgetInfo.minResizeHeight.toDp()
             } else {
                 widgetInfo.minHeight.toDp()
@@ -404,6 +402,7 @@ fun ColumnScope.ConfigureAppWidget(
 
             DragResizeHandle(
                 alignment = Alignment.TopCenter,
+                forceResize = widget.config.forceResize,
                 resizeAxis = if (minWidth == maxWidth && minHeight == maxHeight) ResizeAxis.None
                     else if (minWidth == maxWidth) ResizeAxis.Vertical
                     else if (minHeight == maxHeight) ResizeAxis.Horizontal
@@ -425,7 +424,7 @@ fun ColumnScope.ConfigureAppWidget(
                         widget.copy(
                             config = widget.config.copy(
                                 height = resizeHeight.value.roundToInt(),
-                                width = resizeWidth.takeIf { it != Dp.Unspecified }?.value?.roundToInt()
+                                width = resizeWidth.takeIf { !it.isUnspecified }?.value?.roundToInt()
                             )
                         )
                     )

--- a/core/i18n/src/main/res/values/strings.xml
+++ b/core/i18n/src/main/res/values/strings.xml
@@ -782,6 +782,7 @@
     <string name="widget_config_appwidget_background">Background card</string>
     <string name="widget_config_appwidget_configure">Configure widget</string>
     <string name="widget_config_appwidget_resize">Resize</string>
+    <string name="widget_config_appwidget_force_resize">Force resize widget</string>
     <string name="widget_config_weather_integration_settings">Weather integration settings</string>
     <string name="widget_config_calendar_no_calendars">No calendars found</string>
     <string name="widget_pick_widget">Pick widget</string>

--- a/data/widgets/src/main/java/de/mm20/launcher2/widgets/AppWidget.kt
+++ b/data/widgets/src/main/java/de/mm20/launcher2/widgets/AppWidget.kt
@@ -1,10 +1,5 @@
 package de.mm20.launcher2.widgets
 
-import android.app.Activity
-import android.appwidget.AppWidgetHost
-import android.appwidget.AppWidgetProviderInfo
-import android.content.Context
-import android.os.Build
 import de.mm20.launcher2.database.entities.PartialWidgetEntity
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
@@ -18,6 +13,7 @@ data class AppWidgetConfig(
     val width: Int? = null,
     val borderless: Boolean = false,
     val background: Boolean = true,
+    val forceResize: Boolean = false,
     val themeColors: Boolean = true,
 )
 


### PR DESCRIPTION
Right now when you try to resize a widget to less than 128dp the handles attached to the resizable frame detach which looks weird.

This pr fixes that and also:
- Increases the area from which the left handle can be grabbed from as the system often misinterprets my attempts to grab it as a 'back' gesture
- The widget can be resized by grabbing anywhere on its side as well