### PR TITLE
Improve place search speed by ~10x

### DIFF
--- a/data/locations/src/main/java/de/mm20/launcher2/locations/providers/openstreetmaps/OsmLocationProvider.kt
+++ b/data/locations/src/main/java/de/mm20/launcher2/locations/providers/openstreetmaps/OsmLocationProvider.kt
@@ -141,7 +141,7 @@ internal class OsmLocationProvider(
         return result
             .asSequence()
             .filter {
-                !hideUncategorized || (it.category != null)
+                (!hideUncategorized || (it.category != null)) && it.distanceTo(userLocation) < searchRadiusMeters
             }
             .groupBy {
                 it.label.lowercase()

--- a/data/locations/src/main/java/de/mm20/launcher2/locations/providers/openstreetmaps/OverpassApi.kt
+++ b/data/locations/src/main/java/de/mm20/launcher2/locations/providers/openstreetmaps/OverpassApi.kt
@@ -7,6 +7,7 @@ import retrofit2.Retrofit
 import retrofit2.http.Body
 import retrofit2.http.POST
 import java.lang.reflect.Type
+import kotlin.math.cos
 
 data class OverpassFuzzyRadiusQuery(
     val tag: String = "name",
@@ -62,9 +63,10 @@ class OverpassFuzzyRadiusQueryConverter : Converter<OverpassFuzzyRadiusQuery, Re
             ) { Regex.escapeReplacement(it) }
 
         val overpassQlBuilder = StringBuilder()
-        val degreeChange = value.radius * 0.00001
-        val boundingBox = arrayOf(value.latitude - degreeChange, value.longitude - degreeChange,
-            value.latitude + degreeChange, value.longitude + degreeChange)
+        val latDegreeChange = value.radius * 0.00001 / 1.11
+        val lonDegreeChange = latDegreeChange / cos(Math.toRadians(value.latitude))
+        val boundingBox = arrayOf(value.latitude - latDegreeChange, value.longitude - lonDegreeChange,
+            value.latitude + latDegreeChange, value.longitude + lonDegreeChange)
         overpassQlBuilder.append("[out:json][timeout:10][bbox:" + boundingBox.joinToString(",") + "];")
         // nw: node or way
         overpassQlBuilder.append("nw[", value.tag, "~", escapedQueryName, if (value.caseInvariant) ",i];" else "];")

--- a/data/locations/src/main/java/de/mm20/launcher2/locations/providers/openstreetmaps/OverpassApi.kt
+++ b/data/locations/src/main/java/de/mm20/launcher2/locations/providers/openstreetmaps/OverpassApi.kt
@@ -62,10 +62,12 @@ class OverpassFuzzyRadiusQueryConverter : Converter<OverpassFuzzyRadiusQuery, Re
             ) { Regex.escapeReplacement(it) }
 
         val overpassQlBuilder = StringBuilder()
-        overpassQlBuilder.append("[out:json];")
+        val degreeChange = value.radius * 0.00001
+        val boundingBox = arrayOf(value.latitude - degreeChange, value.longitude - degreeChange,
+            value.latitude + degreeChange, value.longitude + degreeChange)
+        overpassQlBuilder.append("[out:json][timeout:10][bbox:" + boundingBox.joinToString(",") + "];")
         // nw: node or way
-        overpassQlBuilder.append("nw(around:", value.radius, ',', value.latitude, ',', value.longitude, ')')
-        overpassQlBuilder.append('[', value.tag, '~', escapedQueryName, if (value.caseInvariant) ",i];" else "];")
+        overpassQlBuilder.append("nw[", value.tag, "~", escapedQueryName, if (value.caseInvariant) ",i];" else "];")
         // center to add the center coordinate of a way to the result, if applicable
         overpassQlBuilder.append("out center;")
 


### PR DESCRIPTION
I was testing to see why places search did not work for me but it seems like it was just incredibly sluggish.
The culprit was the `around` parameter which is very very slow for some reason. I changed it to use a bounding box and that had a huge impact where a simple search of around 4km went from 10s to less than 1 for me.

The only downside is that the radius setting is mostly inaccurate as bounding box parameters are degrees and not meters. I used an approximation where 0.00001deg is around 1.1m, so if the radius is set to 4km, the results will come from around 4.5km radius (actually more since the bounding box is a rectangle and not a circle, so at the extreme you could get results from up to 6.3km)

Not sure what to do with the setting though - maybe make the settings vague to reduce the impression of specificity... Or maybe the results should be filtered out and discarded if they are too far away.