### PR TITLE
Fix crash after tapping "Configure widget" in Settings

### DIFF
--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/sheets/ConfigureWidgetSheet.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/sheets/ConfigureWidgetSheet.kt
@@ -478,9 +478,6 @@ fun ColumnScope.ConfigureAppWidget(
                                 .setPendingIntentBackgroundActivityStartMode(
                                     ActivityOptions.MODE_BACKGROUND_ACTIVITY_START_ALLOWED
                                 )
-                                .setPendingIntentCreatorBackgroundActivityStartMode(
-                                    ActivityOptions.MODE_BACKGROUND_ACTIVITY_START_ALLOWED
-                                )
                                 .toBundle()
                         }
                     )

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/widgets/clock/WatchFaceSelector.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/widgets/clock/WatchFaceSelector.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.app.ActivityOptions
 import android.appwidget.AppWidgetManager
 import android.content.Context
+import android.content.ContextWrapper
 import android.os.Build
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.animateContentSize
@@ -210,7 +211,7 @@ fun WatchFaceSelector(
                                             },
                                             onClick = {
                                                 appWidgetHost.startAppWidgetConfigureActivityForResult(
-                                                    context as Activity,
+                                                    getActivityFromContext(context) ?: return@DropdownMenuItem,
                                                     selected.widgetId ?: return@DropdownMenuItem,
                                                     0,
                                                     0,
@@ -219,9 +220,6 @@ fun WatchFaceSelector(
                                                     } else {
                                                         ActivityOptions.makeBasic()
                                                             .setPendingIntentBackgroundActivityStartMode(
-                                                                ActivityOptions.MODE_BACKGROUND_ACTIVITY_START_ALLOWED
-                                                            )
-                                                            .setPendingIntentCreatorBackgroundActivityStartMode(
                                                                 ActivityOptions.MODE_BACKGROUND_ACTIVITY_START_ALLOWED
                                                             )
                                                             .toBundle()
@@ -588,4 +586,18 @@ private fun ResizeCustomWidget(
             }
         }
     }
+}
+
+private fun getActivityFromContext(context: Context): Activity? {
+    var activity = context
+
+    while (activity is ContextWrapper) {
+        if (activity is Activity) {
+            return activity
+        }
+
+        activity = activity.baseContext
+    }
+
+    return null
 }


### PR DESCRIPTION
## Description

Greetings! I was able to reproduce the original bug report in #1221. My stack trace is attached here:

<details>
<summary>java.lang.IllegalArgumentException: pendingIntentCreatorBackgroundActivityStartMode must not be set when sending a PendingIntent</summary>

```
FATAL EXCEPTION: main
Process: de.mm20.launcher2.debug, PID: 12890
java.lang.IllegalArgumentException: pendingIntentCreatorBackgroundActivityStartMode must not be set when sending a PendingIntent
	at android.os.Parcel.createExceptionOrNull(Parcel.java:3246)
	at android.os.Parcel.createException(Parcel.java:3226)
	at android.os.Parcel.readException(Parcel.java:3209)
	at android.os.Parcel.readException(Parcel.java:3151)
	at android.app.IActivityTaskManager$Stub$Proxy.startActivityIntentSender(IActivityTaskManager.java:2171)
	at android.app.Activity.startIntentSenderForResultInner(Activity.java:6254)
	at android.app.Activity.startIntentSenderForResult(Activity.java:6225)
	at androidx.activity.ComponentActivity.startIntentSenderForResult(ComponentActivity.kt:764)
	at android.appwidget.AppWidgetHost.startAppWidgetConfigureActivityForResult(AppWidgetHost.java:336)
	at de.mm20.launcher2.ui.launcher.widgets.clock.WatchFaceSelectorKt$WatchFaceSelector$1$1$3$2$1$2$2.invoke$lambda$8$lambda$7(WatchFaceSelector.kt:213)
	at de.mm20.launcher2.ui.launcher.widgets.clock.WatchFaceSelectorKt$WatchFaceSelector$1$1$3$2$1$2$2.$r8$lambda$CHKc5RQzubjg-daGRTHINCq2JOM(Unknown Source:0)
	at de.mm20.launcher2.ui.launcher.widgets.clock.WatchFaceSelectorKt$WatchFaceSelector$1$1$3$2$1$2$2$$ExternalSyntheticLambda3.invoke(Unknown Source:6)
	at androidx.compose.foundation.ClickableNode$clickPointerInput$3.invoke-k-4lQ0M(Clickable.kt:677)
	at androidx.compose.foundation.ClickableNode$clickPointerInput$3.invoke(Clickable.kt:671)
	at androidx.compose.foundation.gestures.TapGestureDetectorKt$detectTapAndPress$2$1.invokeSuspend(TapGestureDetector.kt:296)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTaskKt.resume(DispatchedTask.kt:175)
	at kotlinx.coroutines.DispatchedTaskKt.dispatch(DispatchedTask.kt:164)
	at kotlinx.coroutines.CancellableContinuationImpl.dispatchResume(CancellableContinuationImpl.kt:466)
	at kotlinx.coroutines.CancellableContinuationImpl.resumeImpl(CancellableContinuationImpl.kt:500)
	at kotlinx.coroutines.CancellableContinuationImpl.resumeImpl$default(CancellableContinuationImpl.kt:489)
	at kotlinx.coroutines.CancellableContinuationImpl.resumeWith(CancellableContinuationImpl.kt:364)
	at androidx.compose.ui.input.pointer.SuspendingPointerInputModifierNodeImpl$PointerEventHandlerCoroutine.offerPointerEvent(SuspendingPointerInputFilter.kt:825)
	at androidx.compose.ui.input.pointer.SuspendingPointerInputModifierNodeImpl.dispatchPointerEvent(SuspendingPointerInputFilter.kt:693)
	at androidx.compose.ui.input.pointer.SuspendingPointerInputModifierNodeImpl.onPointerEvent-H0pRuoY(SuspendingPointerInputFilter.kt:719)
	at androidx.compose.foundation.AbstractClickableNode.onPointerEvent-H0pRuoY(Clickable.kt:1137)
	at androidx.compose.ui.input.pointer.Node.dispatchMainEventPass(HitPathTracker.kt:391)
	at androidx.compose.ui.input.pointer.Node.dispatchMainEventPass(HitPathTracker.kt:377)
	at androidx.compose.ui.input.pointer.Node.dispatchMainEventPass(HitPathTracker.kt:377)
	at androidx.compose.ui.input.pointer.Node.dispatchMainEventPass(HitPathTracker.kt:377)
	at androidx.compose.ui.input.pointer.NodeParent.dispatchMainEventPass(HitPathTracker.kt:230)
	at androidx.compose.ui.input.pointer.HitPathTracker.dispatchChanges(HitPathTracker.kt:154)
	at androidx.compose.ui.input.pointer.PointerInputEventProcessor.process-BIzXfog(PointerInputEventProcessor.kt:117)
	at androidx.compose.ui.platform.AndroidComposeView.sendMotionEvent-8iAsVTc(AndroidComposeView.android.kt:2115)
	at androidx.compose.ui.platform.AndroidComposeView.handleMotionEvent-8iAsVTc(AndroidComposeView.android.kt:2065)
	at androidx.compose.ui.platform.AndroidComposeView.dispatchTouchEvent(AndroidComposeView.android.kt:1936)
	at android.view.ViewGroup.dispatchTransformedTouchEvent(ViewGroup.java:3122)
	at android.view.ViewGroup.dispatchTouchEvent(ViewGroup.java:2803)
	at android.view.View.dispatchPointerEvent(View.java:16729)

```
</details>

I simply followed the message's suggestion and thus removed `pendingIntentCreatorBackgroundActivityStartMode()` from `ActivityOptions`, which seems to have fixed this issue.

However, in uncertain circumstances, I also got this error:

<details>
<summary>java.lang.ClassCastException: android.view.ContextThemeWrapper cannot be cast to android.app.Activity</summary>

```
java.lang.ClassCastException: android.view.ContextThemeWrapper cannot be cast to android.app.Activity
	at de.mm20.launcher2.ui.launcher.widgets.clock.WatchFaceSelectorKt$WatchFaceSelector$1$1$3$2$1$2$2.invoke$lambda$8$lambda$7(WatchFaceSelector.kt:213)
	at de.mm20.launcher2.ui.launcher.widgets.clock.WatchFaceSelectorKt$WatchFaceSelector$1$1$3$2$1$2$2.$r8$lambda$CHKc5RQzubjg-daGRTHINCq2JOM(Unknown Source:0)
	at de.mm20.launcher2.ui.launcher.widgets.clock.WatchFaceSelectorKt$WatchFaceSelector$1$1$3$2$1$2$2$$ExternalSyntheticLambda3.invoke(Unknown Source:6)
	at androidx.compose.foundation.ClickableNode$clickPointerInput$3.invoke-k-4lQ0M(Clickable.kt:677)
	at androidx.compose.foundation.ClickableNode$clickPointerInput$3.invoke(Clickable.kt:671)
	at androidx.compose.foundation.gestures.TapGestureDetectorKt$detectTapAndPress$2$1.invokeSuspend(TapGestureDetector.kt:296)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTaskKt.resume(DispatchedTask.kt:175)
	at kotlinx.coroutines.DispatchedTaskKt.dispatch(DispatchedTask.kt:164)
	at kotlinx.coroutines.CancellableContinuationImpl.dispatchResume(CancellableContinuationImpl.kt:466)
	at kotlinx.coroutines.CancellableContinuationImpl.resumeImpl(CancellableContinuationImpl.kt:500)
	at kotlinx.coroutines.CancellableContinuationImpl.resumeImpl$default(CancellableContinuationImpl.kt:489)
	at kotlinx.coroutines.CancellableContinuationImpl.resumeWith(CancellableContinuationImpl.kt:364)
	at androidx.compose.ui.input.pointer.SuspendingPointerInputModifierNodeImpl$PointerEventHandlerCoroutine.offerPointerEvent(SuspendingPointerInputFilter.kt:825)
	at androidx.compose.ui.input.pointer.SuspendingPointerInputModifierNodeImpl.dispatchPointerEvent(SuspendingPointerInputFilter.kt:693)
	at androidx.compose.ui.input.pointer.SuspendingPointerInputModifierNodeImpl.onPointerEvent-H0pRuoY(SuspendingPointerInputFilter.kt:719)
	at androidx.compose.foundation.AbstractClickableNode.onPointerEvent-H0pRuoY(Clickable.kt:1137)
	at androidx.compose.ui.input.pointer.Node.dispatchMainEventPass(HitPathTracker.kt:391)
	at androidx.compose.ui.input.pointer.Node.dispatchMainEventPass(HitPathTracker.kt:377)
	at androidx.compose.ui.input.pointer.Node.dispatchMainEventPass(HitPathTracker.kt:377)
	at androidx.compose.ui.input.pointer.Node.dispatchMainEventPass(HitPathTracker.kt:377)
	at androidx.compose.ui.input.pointer.NodeParent.dispatchMainEventPass(HitPathTracker.kt:230)
	at androidx.compose.ui.input.pointer.HitPathTracker.dispatchChanges(HitPathTracker.kt:154)
	at androidx.compose.ui.input.pointer.PointerInputEventProcessor.process-BIzXfog(PointerInputEventProcessor.kt:117)
	at androidx.compose.ui.platform.AndroidComposeView.sendMotionEvent-8iAsVTc(AndroidComposeView.android.kt:2115)
	at androidx.compose.ui.platform.AndroidComposeView.handleMotionEvent-8iAsVTc(AndroidComposeView.android.kt:2065)
	at androidx.compose.ui.platform.AndroidComposeView.dispatchTouchEvent(AndroidComposeView.android.kt:1936)
	at android.view.ViewGroup.dispatchTransformedTouchEvent(ViewGroup.java:3122)
	at android.view.ViewGroup.dispatchTouchEvent(ViewGroup.java:2803)
	at android.view.View.dispatchPointerEvent(View.java:16729)
	at android.view.ViewRootImpl$ViewPostImeInputStage.processPointerEvent(ViewRootImpl.java:7947)
	at android.view.ViewRootImpl$ViewPostImeInputStage.onProcess(ViewRootImpl.java:7710)
	at android.view.ViewRootImpl$InputStage.deliver(ViewRootImpl.java:7106)
	at android.view.ViewRootImpl$InputStage.onDeliverToNext(ViewRootImpl.java:7163)
	at android.view.ViewRootImpl$InputStage.forward(ViewRootImpl.java:7129)
	at android.view.ViewRootImpl$AsyncInputStage.forward(ViewRootImpl.java:7295)
	at android.view.ViewRootImpl$InputStage.apply(ViewRootImpl.java:7137)
	at android.view.ViewRootImpl$AsyncInputStage.apply(ViewRootImpl.java:7352)
	at android.view.ViewRootImpl$InputStage.deliver(ViewRootImpl.java:7110)
```
</details>

To fix it, I added a `getActivityFromContext()` function that traverses through base contexts, starting from the current context until it finds a Context cast-able to Activity. Now, if it can't "cast" `context` to an Activity, it will silently fail instead of crashing. I'm not sure if that's desirable; I could switch to a non-null assertion if it's better in your opinion.

A strange issue I encountered, is that the widget on the home screen doesn't reflect any changes made after configuration until I force stop the application. I only tried it with the stock Clock app on Android Studio's emulator (Android 15); I don't know if it happens with other widgets.
I'm not sure why that happens. I would appreciate some help regarding that, if it is a deal breaker. Perhaps another PR could take care of that issue?
