### PR TITLE
Collapse search objects on query change

### DIFF
--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/search/SearchColumn.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/search/SearchColumn.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -118,6 +119,18 @@ fun SearchColumn(
     var selectedShortcutIndex: Int by remember(appShortcuts) { mutableIntStateOf(-1) }
     var selectedArticleIndex: Int by remember(wikipedia) { mutableIntStateOf(-1) }
     var selectedWebsiteIndex: Int by remember(website) { mutableIntStateOf(-1) }
+
+    val query by viewModel.searchQuery
+    LaunchedEffect(query) {
+        selectedAppProfileIndex = 0
+        selectedContactIndex = -1
+        selectedFileIndex = -1
+        selectedCalendarIndex = -1
+        selectedLocationIndex = -1
+        selectedShortcutIndex = -1
+        selectedArticleIndex = -1
+        selectedWebsiteIndex = -1
+    }
 
     val showFilters by viewModel.showFilters
 

--- a/core/preferences/src/main/java/de/mm20/launcher2/preferences/search/LocationSearchSettings.kt
+++ b/core/preferences/src/main/java/de/mm20/launcher2/preferences/search/LocationSearchSettings.kt
@@ -74,9 +74,7 @@ class LocationSearchSettings internal constructor(
 
     fun setOverpassUrl(overpassUrl: String?) {
         var url = overpassUrl
-        if (url.isNullOrBlank()) {
-            url = DefaultOverpassUrl
-        } else {
+        if (url != null) {
             if (!url.startsWith("http://") && !url.startsWith("https://")) {
                 url = "https://$url"
             }
@@ -97,9 +95,7 @@ class LocationSearchSettings internal constructor(
 
     fun setTileServer(tileServer: String?) {
         var url = tileServer
-        if (url.isNullOrBlank()) {
-            url = DefaultTileServerUrl
-        } else {
+        if (url != null) {
             if (!url.startsWith("http://") && !url.startsWith("https://")) {
                 url = "https://$url"
             }
@@ -140,8 +136,8 @@ class LocationSearchSettings internal constructor(
     }
 
     companion object {
-        const val DefaultTileServerUrl = "https://tile.openstreetmap.org/\${z}/\${x}/\${y}.png"
-        const val DefaultOverpassUrl = "https://overpass-api.de"
+        const val DefaultTileServerUrl = "https://tile.openstreetmap.org"
+        const val DefaultOverpassUrl = "https://overpass-api.de/"
     }
 
 }

--- a/core/preferences/src/main/java/de/mm20/launcher2/preferences/search/LocationSearchSettings.kt
+++ b/core/preferences/src/main/java/de/mm20/launcher2/preferences/search/LocationSearchSettings.kt
@@ -74,7 +74,9 @@ class LocationSearchSettings internal constructor(
 
     fun setOverpassUrl(overpassUrl: String?) {
         var url = overpassUrl
-        if (url != null) {
+        if (url.isNullOrBlank()) {
+            url = DefaultOverpassUrl
+        } else {
             if (!url.startsWith("http://") && !url.startsWith("https://")) {
                 url = "https://$url"
             }
@@ -95,7 +97,9 @@ class LocationSearchSettings internal constructor(
 
     fun setTileServer(tileServer: String?) {
         var url = tileServer
-        if (url != null) {
+        if (url.isNullOrBlank()) {
+            url = DefaultTileServerUrl
+        } else {
             if (!url.startsWith("http://") && !url.startsWith("https://")) {
                 url = "https://$url"
             }
@@ -136,8 +140,8 @@ class LocationSearchSettings internal constructor(
     }
 
     companion object {
-        const val DefaultTileServerUrl = "https://tile.openstreetmap.org"
-        const val DefaultOverpassUrl = "https://overpass-api.de/"
+        const val DefaultTileServerUrl = "https://tile.openstreetmap.org/\${z}/\${x}/\${y}.png"
+        const val DefaultOverpassUrl = "https://overpass-api.de"
     }
 
 }


### PR DESCRIPTION
Right now whenever you expand something like a contact, it will stay open taking up a lot of space in subsequent searches