### PR TITLE
Add customizable action on clock widget tap

### DIFF
--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/widgets/clock/ClockWidget.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/widgets/clock/ClockWidget.kt
@@ -1,5 +1,6 @@
 package de.mm20.launcher2.ui.launcher.widgets.clock
 
+import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
@@ -65,16 +66,20 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import de.mm20.launcher2.ktx.isAtLeastApiLevel
 import de.mm20.launcher2.preferences.ClockWidgetAlignment
 import de.mm20.launcher2.preferences.ClockWidgetColors
 import de.mm20.launcher2.preferences.ClockWidgetStyle
+import de.mm20.launcher2.preferences.GestureAction
 import de.mm20.launcher2.preferences.TimeFormat
 import de.mm20.launcher2.preferences.ui.ClockWidgetSettings
 import de.mm20.launcher2.ui.R
 import de.mm20.launcher2.ui.base.LocalTime
 import de.mm20.launcher2.ui.component.BottomSheetDialog
+import de.mm20.launcher2.ui.component.MissingPermissionBanner
 import de.mm20.launcher2.ui.component.preferences.Preference
 import de.mm20.launcher2.ui.component.preferences.SwitchPreference
+import de.mm20.launcher2.ui.ktx.toPixels
 import de.mm20.launcher2.ui.launcher.widgets.clock.clocks.AnalogClock
 import de.mm20.launcher2.ui.launcher.widgets.clock.clocks.BinaryClock
 import de.mm20.launcher2.ui.launcher.widgets.clock.clocks.CustomClock
@@ -85,6 +90,8 @@ import de.mm20.launcher2.ui.launcher.widgets.clock.clocks.SegmentClock
 import de.mm20.launcher2.ui.launcher.widgets.clock.parts.PartProvider
 import de.mm20.launcher2.ui.locals.LocalPreferDarkContentOverWallpaper
 import de.mm20.launcher2.ui.settings.clockwidget.ClockWidgetSettingsScreenVM
+import de.mm20.launcher2.ui.settings.gestures.GesturePreference
+import de.mm20.launcher2.ui.settings.gestures.requiresAccessibilityService
 import de.mm20.launcher2.ui.utils.isTwentyFourHours
 import org.koin.androidx.compose.inject
 
@@ -576,6 +583,29 @@ fun ConfigureClockWidgetSheet(
                             viewModel.setFillHeight(it)
                         }
                     )
+
+                    val options = buildList {
+                        add(stringResource(R.string.gesture_action_none) to GestureAction.NoAction)
+                        add(stringResource(R.string.gesture_action_alarms) to GestureAction.Alarms)
+                        add(stringResource(R.string.gesture_action_launch_app) to GestureAction.Launch(null))
+                    }
+                    val appIconSize = 32.dp.toPixels()
+                    val tapAction by viewModel.tapAction.collectAsStateWithLifecycle(null)
+                    val tapApp by viewModel.tapApp.collectAsState(null)
+                    val tapAppIcon by remember(tapApp?.key) {
+                        viewModel.getIcon(tapApp, appIconSize.toInt())
+                    }.collectAsState(null)
+                    GesturePreference(
+                        title = stringResource(R.string.preference_gesture_tap),
+                        value = tapAction,
+                        onValueChanged = { viewModel.setTapAction(it) },
+                        isOpenSearch = false,
+                        options = options,
+                        app = tapApp,
+                        appIcon = tapAppIcon,
+                        onAppChanged = { viewModel.setTapApp(it) }
+                    )
+
                     AnimatedVisibility(fillHeight == true) {
                         var showDropdown by remember { mutableStateOf(false) }
                         Preference(

--- a/core/i18n/src/main/res/values/strings.xml
+++ b/core/i18n/src/main/res/values/strings.xml
@@ -764,8 +764,10 @@
     <string name="preference_gesture_swipe_left">Swipe left</string>
     <string name="preference_gesture_swipe_right">Swipe right</string>
     <string name="preference_gesture_double_tap">Double tap</string>
+    <string name="preference_gesture_tap">Tap</string>
     <string name="preference_gesture_long_press">Long press</string>
     <string name="preference_gesture_home_button">Home button/gesture</string>
+    <string name="gesture_action_alarms">Show alarms</string>
     <string name="gesture_action_none">Do nothing</string>
     <string name="gesture_action_open_search">Open search</string>
     <string name="gesture_action_launch_app">Launch app</string>

--- a/core/preferences/src/main/java/de/mm20/launcher2/preferences/LauncherSettingsData.kt
+++ b/core/preferences/src/main/java/de/mm20/launcher2/preferences/LauncherSettingsData.kt
@@ -42,6 +42,7 @@ data class LauncherSettingsData internal constructor(
     val clockWidgetDatePart: Boolean = true,
     val clockWidgetFillHeight: Boolean = true,
     val clockWidgetAlignment: ClockWidgetAlignment = ClockWidgetAlignment.Bottom,
+    val clockTapAction: GestureAction = GestureAction.Alarms,
 
     val homeScreenDock: Boolean = false,
 
@@ -373,6 +374,10 @@ sealed interface GestureAction {
     @Serializable
     @SerialName("launch_searchable")
     data class Launch(val key: String?) : GestureAction
+
+    @Serializable
+    @SerialName("alarms")
+    data object Alarms : GestureAction
 }
 
 

--- a/core/preferences/src/main/java/de/mm20/launcher2/preferences/ui/ClockWidgetSettings.kt
+++ b/core/preferences/src/main/java/de/mm20/launcher2/preferences/ui/ClockWidgetSettings.kt
@@ -4,6 +4,7 @@ import de.mm20.launcher2.preferences.ClockWidgetAlignment
 import de.mm20.launcher2.preferences.ClockWidgetColors
 import de.mm20.launcher2.preferences.ClockWidgetStyle
 import de.mm20.launcher2.preferences.ClockWidgetStyleEnum
+import de.mm20.launcher2.preferences.GestureAction
 import de.mm20.launcher2.preferences.LauncherDataStore
 import de.mm20.launcher2.preferences.TimeFormat
 import kotlinx.coroutines.flow.Flow
@@ -69,6 +70,15 @@ class ClockWidgetSettings internal constructor(
     fun setFillHeight(fillHeight: Boolean) {
         launcherDataStore.update {
             it.copy(clockWidgetFillHeight = fillHeight)
+        }
+    }
+
+    val tapAction: Flow<GestureAction> = launcherDataStore.data.map { it.clockTapAction }
+        .distinctUntilChanged()
+
+    fun setTapAction(action: GestureAction) {
+        launcherDataStore.update {
+            it.copy(clockTapAction = action)
         }
     }
 


### PR DESCRIPTION
Hi, here is a feature suggestion for more customization. Namely, being able to change what happens when tapping on the clock widget.
I had this idea because my stupid clock app (Samsung) does not show all options/menus when launched through the `ACTION_SHOW_ALARMS` intent. But I believe it could be used for anything else.

<img src="https://github.com/user-attachments/assets/0271dc70-5fdc-47b8-813b-4fe2105cd87e" width="200" />
<img src="https://github.com/user-attachments/assets/86504212-94f9-4a95-8a19-f35b011ba157" width="200" />
<img src="https://github.com/user-attachments/assets/d01123b5-a6c9-4c26-a9f3-bab22f225fa9" width="200" />

This PR is just a draft to have some feedback.

I reused the gesture machinery, but if you're ok to integrate such feature, I would propose to refactor the `GestureAction` to make it more generic and reusable in different places.

Let me know what you think,