### PR TITLE
Add option to invert favorite tags position

### DIFF
--- a/app/ui/src/main/java/de/mm20/launcher2/ui/common/FavoritesVM.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/common/FavoritesVM.kt
@@ -28,6 +28,7 @@ abstract class FavoritesVM : ViewModel(), KoinComponent {
     val showEditButton = settings.showEditButton.stateIn(viewModelScope, SharingStarted.Lazily, false)
     abstract val tagsExpanded: Flow<Boolean>
     abstract val compactTags: Flow<Boolean>
+    abstract val tagsPosition: Flow<Boolean>
 
     val pinnedTags = favoritesService.getFavorites(
         includeTypes = listOf("tag"),

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/search/SearchColumn.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/search/SearchColumn.kt
@@ -107,6 +107,7 @@ fun SearchColumn(
     val compactTags by favoritesVM.compactTags.collectAsState(false)
     val favoritesEditButton by favoritesVM.showEditButton.collectAsState(false)
     val favoritesTagsExpanded by favoritesVM.tagsExpanded.collectAsState(false)
+    val tagsPosition by favoritesVM.tagsPosition.collectAsState(false)
 
     val expandedCategory: SearchCategory? by viewModel.expandedCategory
 
@@ -169,7 +170,8 @@ fun SearchColumn(
                             favoritesVM.setTagsExpanded(it)
                         },
                         compactTags = compactTags,
-                        editButton = favoritesEditButton
+                        editButton = favoritesEditButton,
+                        tagsPosition = tagsPosition,
                     )
                 }
 

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/search/favorites/SearchFavorites.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/search/favorites/SearchFavorites.kt
@@ -34,6 +34,7 @@ fun LazyListScope.SearchFavorites(
     onSelectTag: (String?) -> Unit,
     editButton: Boolean,
     reverse: Boolean,
+    tagsPosition: Boolean,
 ) {
     item(
         key = "favorites",
@@ -53,6 +54,19 @@ fun LazyListScope.SearchFavorites(
                     ),
                 verticalArrangement = if (reverse) Arrangement.BottomReversed else Arrangement.Top
             ) {
+                if (tagsPosition && (pinnedTags.isNotEmpty() || editButton)) {
+                    FavoritesTagSelector(
+                        tags = pinnedTags,
+                        selectedTag = selectedTag,
+                        editButton = editButton,
+                        reverse = reverse,
+                        onSelectTag = onSelectTag,
+                        scrollState = rememberScrollState(),
+                        expanded = tagsExpanded,
+                        compact = compactTags,
+                        onExpand = onExpandTags,
+                    )
+                }
                 if (favorites.isNotEmpty()) {
                     SearchResultGrid(favorites, transitionKey = selectedTag, reverse = reverse)
                 } else {
@@ -64,12 +78,12 @@ fun LazyListScope.SearchFavorites(
                         icon = if (selectedTag == null) Icons.Rounded.Star else Icons.Rounded.Tag,
                     )
                 }
-                if (pinnedTags.isNotEmpty() || editButton) {
+                if (!tagsPosition && (pinnedTags.isNotEmpty() || editButton)) {
                     FavoritesTagSelector(
                         tags = pinnedTags,
                         selectedTag = selectedTag,
                         editButton = editButton,
-                        reverse = false,
+                        reverse = reverse,
                         onSelectTag = onSelectTag,
                         scrollState = rememberScrollState(),
                         expanded = tagsExpanded,

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/search/favorites/SearchFavoritesVM.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/search/favorites/SearchFavoritesVM.kt
@@ -21,4 +21,5 @@ class SearchFavoritesVM : FavoritesVM() {
 
     override val compactTags: Flow<Boolean> = settings.compactTags
 
+    override val tagsPosition: Flow<Boolean> = settings.tagsPosition
 }

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/widgets/favorites/FavoritesWidget.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/widgets/favorites/FavoritesWidget.kt
@@ -33,6 +33,7 @@ fun FavoritesWidget(widget: FavoritesWidget) {
     val pinnedTags by viewModel.pinnedTags.collectAsState(emptyList())
     val selectedTag by viewModel.selectedTag.collectAsState(null)
     val compactTags by viewModel.compactTags.collectAsState(false)
+    val tagsPosition by viewModel.tagsPosition.collectAsState(false)
     val favoritesEditButton = widget.config.editButton
 
     val tagsExpanded by viewModel.tagsExpanded.collectAsState(false)
@@ -42,6 +43,19 @@ fun FavoritesWidget(widget: FavoritesWidget) {
     }
 
     Column {
+        if (tagsPosition && (pinnedTags.isNotEmpty() || favoritesEditButton)) {
+            FavoritesTagSelector(
+                tags = pinnedTags,
+                selectedTag = selectedTag,
+                editButton = favoritesEditButton,
+                reverse = false,
+                onSelectTag = { viewModel.selectTag(it) },
+                scrollState = rememberScrollState(),
+                expanded = tagsExpanded,
+                compact = compactTags,
+                onExpand = { viewModel.setTagsExpanded(it) }
+            )
+        }
         if (favorites.isNotEmpty()) {
             SearchResultGrid(favorites, transitionKey = selectedTag)
         } else {
@@ -53,7 +67,7 @@ fun FavoritesWidget(widget: FavoritesWidget) {
                 icon = if (selectedTag == null) Icons.Rounded.Star else Icons.Rounded.Tag,
             )
         }
-        if (pinnedTags.isNotEmpty() || favoritesEditButton) {
+        if (!tagsPosition && (pinnedTags.isNotEmpty() || favoritesEditButton)) {
             FavoritesTagSelector(
                 tags = pinnedTags,
                 selectedTag = selectedTag,

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/widgets/favorites/FavoritesWidgetVM.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/widgets/favorites/FavoritesWidgetVM.kt
@@ -22,6 +22,7 @@ class FavoritesWidgetVM : FavoritesVM() {
     private val widget = MutableStateFlow<FavoritesWidget?>(null)
     override val tagsExpanded = widget.map { it?.config?.tagsMultiline == true }
     override val compactTags: Flow<Boolean> = widget.map { it?.config?.compactTags == true }
+    override val tagsPosition: Flow<Boolean> = widget.map { it?.config?.tagsPosition == true }
 
     private val isTopWidget = widgetsService.isFavoritesWidgetFirst()
     private val clockWidgetFavSlots =

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/settings/favorites/FavoritesSettingsScreen.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/settings/favorites/FavoritesSettingsScreen.kt
@@ -102,6 +102,15 @@ fun FavoritesSettingsScreen() {
                         viewModel.setCompactTags(it)
                     },
                 )
+                val tagsPosition by viewModel.tagsPosition.collectAsState()
+                SwitchPreference(
+                    title = stringResource(R.string.preference_tags_position),
+                    summary = stringResource(R.string.preference_tags_position_summary),
+                    value = tagsPosition == true,
+                    onValueChanged = {
+                        viewModel.setTagsPosition(it)
+                    },
+                )
             }
         }
     }

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/settings/favorites/FavoritesSettingsScreenVM.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/settings/favorites/FavoritesSettingsScreenVM.kt
@@ -45,4 +45,11 @@ class FavoritesSettingsScreenVM: ViewModel(), KoinComponent {
     fun setCompactTags(compactTags: Boolean) {
         favoritesSettings.setCompactTags(compactTags)
     }
+
+    val tagsPosition = favoritesSettings.tagsPosition
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), null)
+    
+    fun setTagsPosition(tagsPosition: Boolean) {
+        favoritesSettings.setTagsPosition(tagsPosition)
+    }
 }

--- a/core/i18n/src/main/res/values/strings.xml
+++ b/core/i18n/src/main/res/values/strings.xml
@@ -654,7 +654,9 @@
     <string name="preference_edit_button">Edit button</string>
     <string name="preference_favorites_edit_button_summary">Show a button to rearrange the favorites</string>
     <string name="preference_compact_tags">Compact tags</string>
-    <string name="preference_compact_tags_summary">Hide tag labels or icons to reduce the space occupied by tags</string>
+    <string name="preference_compact_tags_summary">Show tags in a more compact layout</string>
+    <string name="preference_tags_position">Invert tags position</string>
+    <string name="preference_tags_position_summary">Invert the position of tags above or below the app grid</string>
     <string name="preference_widgets_edit_button_summary">Show a button to add, remove and rearrange widgets</string>
     <string name="preference_screen_homescreen">Home screen</string>
     <string name="preference_screen_homescreen_summary">Clock, search bar, wallpaper, system bars</string>

--- a/core/preferences/src/main/java/de/mm20/launcher2/preferences/LauncherSettingsData.kt
+++ b/core/preferences/src/main/java/de/mm20/launcher2/preferences/LauncherSettingsData.kt
@@ -49,6 +49,7 @@ data class LauncherSettingsData internal constructor(
     val favoritesFrequentlyUsedRows: Int = 1,
     val favoritesEditButton: Boolean = true,
     val favoritesCompactTags: Boolean = false,
+    val favoritesTagsPosition: Boolean = false,
 
     val fileSearchProviders: Set<String> = setOf("local"),
 

--- a/core/preferences/src/main/java/de/mm20/launcher2/preferences/search/FavoritesSettings.kt
+++ b/core/preferences/src/main/java/de/mm20/launcher2/preferences/search/FavoritesSettings.kt
@@ -48,4 +48,11 @@ class FavoritesSettings internal constructor(
     fun setCompactTags(compactTags: Boolean) {
         dataStore.update { it.copy(favoritesCompactTags = compactTags) }
     }
+
+    val tagsPosition: Flow<Boolean>
+        get() = dataStore.data.map { it.favoritesTagsPosition }.distinctUntilChanged()
+
+    fun setTagsPosition(tagsPosition: Boolean) {
+        dataStore.update { it.copy(favoritesTagsPosition = tagsPosition) }
+    }
 }

--- a/data/widgets/src/main/java/de/mm20/launcher2/widgets/FavoritesWidget.kt
+++ b/data/widgets/src/main/java/de/mm20/launcher2/widgets/FavoritesWidget.kt
@@ -11,6 +11,7 @@ data class FavoritesWidgetConfig(
     val editButton: Boolean = true,
     val tagsMultiline: Boolean = false,
     val compactTags: Boolean = false,
+    val tagsPosition: Boolean = false,
 )
 
 data class FavoritesWidget(


### PR DESCRIPTION
Adds an option in the favorites settings to "invert" the position of the tags with respect to the app icons.

The reasoning is that when changing tags that have different number of rows, the tags list jumps around the screen. This makes the tags list position stable.

Current behavior with "Search bar position" set to Bottom:
![image](https://github.com/user-attachments/assets/ff3ede32-ec5b-4c5e-a173-0cfc7003ceed)

With option checked:
![image](https://github.com/user-attachments/assets/306f1edf-317b-439f-9480-909a6d68040f)
