### PR TITLE
Use simple color for icon shape selection

### DIFF
--- a/app/ui/src/main/java/de/mm20/launcher2/ui/settings/icons/IconsSettingsScreen.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/settings/icons/IconsSettingsScreen.kt
@@ -1,6 +1,5 @@
 package de.mm20.launcher2.ui.settings.icons
 
-import android.graphics.drawable.ColorDrawable
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.BorderStroke
@@ -17,9 +16,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.rounded.FormatPaint
 import androidx.compose.material.icons.rounded.Palette
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -42,13 +39,10 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
-import androidx.core.content.ContextCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import de.mm20.launcher2.icons.IconPack
 import de.mm20.launcher2.icons.LauncherIcon
-import de.mm20.launcher2.icons.StaticIconLayer
-import de.mm20.launcher2.icons.StaticLauncherIcon
 import de.mm20.launcher2.preferences.IconShape
 import de.mm20.launcher2.preferences.ui.GridSettings
 import de.mm20.launcher2.ui.R
@@ -430,30 +424,10 @@ fun IconShapePreference(
                                     .padding(8.dp),
                                 horizontalAlignment = Alignment.CenterHorizontally
                             ) {
-                                val context = LocalContext.current
-                                ShapedLauncherIcon(
-                                    size = 48.dp,
-                                    icon = {
-                                        StaticLauncherIcon(
-                                            foregroundLayer = StaticIconLayer(
-                                                icon = ContextCompat.getDrawable(
-                                                    context,
-                                                    R.mipmap.ic_launcher_foreground
-                                                )!!,
-                                                scale = 1.5f,
-                                            ),
-                                            backgroundLayer = StaticIconLayer(
-                                                icon = ColorDrawable(
-                                                    context.getColor(R.color.ic_launcher_background)
-                                                )
-                                            )
-                                        )
-                                    },
-                                    modifier = Modifier.clickable {
-                                        onValueChanged(it)
-                                        showDialog = false
-                                    },
-                                    shape = getShape(it)
+                                Box(
+                                    modifier = Modifier.clip(getShape(it))
+                                        .size(48.dp)
+                                        .background(MaterialTheme.colorScheme.primary)
                                 )
                                 Text(
                                     getShapeName(it) ?: "",


### PR DESCRIPTION
I've found that with certain color schemes it can be quite hard to tell the shapes apart due to poor contrast:
<img src="https://github.com/user-attachments/assets/031fd3cc-4f8a-4436-b051-a4d7e23d6ea9" width="150">

Here's how it looks if instead of the icon there's a simple color:
<img src="https://github.com/user-attachments/assets/9401d28b-317b-4777-bf00-8c1a1d06b505" width="150" >
