### PR TITLE
[Feature] Add configurable amount of rows to the homescreen

### DIFF
--- a/app/ui/src/main/java/de/mm20/launcher2/ui/settings/homescreen/HomescreenSettingsScreen.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/settings/homescreen/HomescreenSettingsScreen.kt
@@ -53,6 +53,7 @@ fun HomescreenSettingsScreen() {
     val context = LocalContext.current
 
     val dock by viewModel.dock.collectAsStateWithLifecycle(null)
+    val rowsInDock by viewModel.rowsInDock.collectAsStateWithLifecycle()
     val fixedRotation by viewModel.fixedRotation.collectAsStateWithLifecycle(null)
     val editButton by viewModel.widgetEditButton.collectAsStateWithLifecycle(null)
     val searchBarStyle by viewModel.searchBarStyle.collectAsStateWithLifecycle(null)
@@ -90,6 +91,19 @@ fun HomescreenSettingsScreen() {
                     onValueChanged = {
                         viewModel.setDock(it)
                     },
+                )
+            }
+
+            AnimatedVisibility(dock == true) {
+                SliderPreference(
+                    title = "Rows",
+                    value = rowsInDock,
+                    onValueChanged = {
+                        viewModel.setRowsInDock(it)
+                    },
+                    min = 1,
+                    max = 5,
+                    step = 1,
                 )
             }
         }

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/settings/homescreen/HomescreenSettingsScreenVM.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/settings/homescreen/HomescreenSettingsScreenVM.kt
@@ -22,7 +22,6 @@ import de.mm20.launcher2.preferences.ui.UiSettings
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.launch
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.get
 
@@ -125,6 +124,13 @@ class HomescreenSettingsScreenVM(
 
     fun setDock(dock: Boolean) {
         clockWidgetSettings.setDock(dock)
+    }
+
+    val rowsInDock = clockWidgetSettings.rowsInDock
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), 1)
+
+    fun setRowsInDock(rowsInDock: Int) {
+        clockWidgetSettings.setRowsInDock(rowsInDock)
     }
 
     val fixedRotation = uiSettings.orientation.map { it != ScreenOrientation.Auto }

--- a/core/preferences/src/main/java/de/mm20/launcher2/preferences/LauncherSettingsData.kt
+++ b/core/preferences/src/main/java/de/mm20/launcher2/preferences/LauncherSettingsData.kt
@@ -1,7 +1,6 @@
 package de.mm20.launcher2.preferences
 
 import android.content.Context
-import de.mm20.launcher2.preferences.search.LocationSearchSettings
 import de.mm20.launcher2.search.SearchFilters
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -45,6 +44,8 @@ data class LauncherSettingsData internal constructor(
 
     val homeScreenDock: Boolean = false,
 
+    val rowsInDock: Int = 5,
+
     val favoritesEnabled: Boolean = true,
     val favoritesFrequentlyUsed: Boolean = true,
     val favoritesFrequentlyUsedRows: Int = 1,
@@ -79,6 +80,7 @@ data class LauncherSettingsData internal constructor(
     val badgesShortcuts: Boolean = true,
     val badgesPlugins: Boolean = true,
 
+    val gridRowCount: Int = 1,
     val gridColumnCount: Int = 5,
     val gridIconSize: Int = 48,
     val gridLabels: Boolean = true,

--- a/core/preferences/src/main/java/de/mm20/launcher2/preferences/ui/ClockWidgetSettings.kt
+++ b/core/preferences/src/main/java/de/mm20/launcher2/preferences/ui/ClockWidgetSettings.kt
@@ -81,6 +81,15 @@ class ClockWidgetSettings internal constructor(
         }
     }
 
+    val rowsInDock
+        get() = launcherDataStore.data.map { it.rowsInDock }
+
+    fun setRowsInDock(rowsInDock: Int) {
+        launcherDataStore.update {
+            it.copy(rowsInDock = rowsInDock)
+        }
+    }
+
     val alignment
         get() = launcherDataStore.data.map { it.clockWidgetAlignment }
 


### PR DESCRIPTION
I just found Kvaesitso and think it is great, but I would love to have more than one row of icons on my dock.

This PR is in a draft state as what I have done isn't working exactly right, but I thought it was a decent start. If anyone wants to work on it with me, by all means.

What works:
  - Changing number of rows in the Clock widget settings

What is broken:
  - Changing the number of Dock rows changes the number of rows in the Favorites widget. I think this is due to how the Dock is a reusable component of the Favorites widget
  - The Dock must be re-rendered in order for the number of rows to be updated. This can be done by toggling the Dock on and off.

Like I said, this is just a start. Hopefully @MM2-0 can check this out and instantly know how to fix the oddities.