### PR TITLE
Remove phone number formatting

### DIFF
--- a/data/contacts/src/main/java/de/mm20/launcher2/contacts/ContactRepository.kt
+++ b/data/contacts/src/main/java/de/mm20/launcher2/contacts/ContactRepository.kt
@@ -179,11 +179,8 @@ internal class ContactRepository(
                     if (Build.VERSION.SDK_INT < 31) {
                         PhoneNumberUtils.compare(context, a.number, b.number)
                     } else {
-                        PhoneNumberUtils.areSamePhoneNumber(a.number, b.number, mainLocaleISO3)
+                        !PhoneNumberUtils.areSamePhoneNumber(a.number, b.number, mainLocaleISO3)
                     }
-                }.mapNotNull {
-                    val formattedNumber = PhoneNumberUtils.formatNumber(it.number, mainLocaleISO3) ?: return@mapNotNull null
-                    it.copy(number = formattedNumber)
                 },
                 emailAddresses = emailAddresses.distinct(),
                 postalAddresses = postalAddresses.distinct(),


### PR DESCRIPTION
It seems like the recent changes have caused most (all?) local phone numbers to be ignored along with special numbers like 112/911.

Also it seems like the logic for dedublicating phone numbers is wrong for APIs >=31.