### PR TITLE
Feature: Lock Single Tag for Favorites Widget

### DIFF
--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/widgets/favorites/FavoritesWidget.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/widgets/favorites/FavoritesWidget.kt
@@ -33,12 +33,18 @@ fun FavoritesWidget(widget: FavoritesWidget) {
     val pinnedTags by viewModel.pinnedTags.collectAsState(emptyList())
     val selectedTag by viewModel.selectedTag.collectAsState(null)
     val compactTags by viewModel.compactTags.collectAsState(false)
+    val singleTag by viewModel.singleTag.collectAsState(false)
+    val singleTagValue by viewModel.singleTagValue.collectAsState("")
     val favoritesEditButton = widget.config.editButton
 
     val tagsExpanded by viewModel.tagsExpanded.collectAsState(false)
 
     LaunchedEffect(widget) {
         viewModel.updateWidget(widget)
+    }
+
+    if(singleTag) {
+        viewModel.selectTag(singleTagValue);
     }
 
     Column(
@@ -56,17 +62,19 @@ fun FavoritesWidget(widget: FavoritesWidget) {
             )
         }
         if (pinnedTags.isNotEmpty() || favoritesEditButton) {
-            FavoritesTagSelector(
-                tags = pinnedTags,
-                selectedTag = selectedTag,
-                editButton = favoritesEditButton,
-                reverse = false,
-                onSelectTag = { viewModel.selectTag(it) },
-                scrollState = rememberScrollState(),
-                expanded = tagsExpanded,
-                compact = compactTags,
-                onExpand = { viewModel.setTagsExpanded(it) }
-            )
+            if(!singleTag) {
+                FavoritesTagSelector(
+                    tags = pinnedTags,
+                    selectedTag = selectedTag,
+                    editButton = favoritesEditButton,
+                    reverse = false,
+                    onSelectTag = { viewModel.selectTag(it) },
+                    scrollState = rememberScrollState(),
+                    expanded = tagsExpanded,
+                    compact = compactTags,
+                    onExpand = { viewModel.setTagsExpanded(it) },
+                )
+            }
         }
     }
 }

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/widgets/favorites/FavoritesWidgetVM.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/widgets/favorites/FavoritesWidgetVM.kt
@@ -22,6 +22,8 @@ class FavoritesWidgetVM : FavoritesVM() {
     private val widget = MutableStateFlow<FavoritesWidget?>(null)
     override val tagsExpanded = widget.map { it?.config?.tagsMultiline == true }
     override val compactTags: Flow<Boolean> = widget.map { it?.config?.compactTags == true }
+    val singleTag: Flow<Boolean> = widget.map { it?.config?.singleTag == true }
+    val singleTagValue: Flow<String> = widget.map { it?.config?.singleTagValue.toString() }
 
     private val isTopWidget = widgetsService.isFavoritesWidgetFirst()
     private val clockWidgetFavSlots =
@@ -36,6 +38,7 @@ class FavoritesWidgetVM : FavoritesVM() {
         }
 
     override val favorites = super.favorites.combine(clockWidgetFavSlots) { favs, slots ->
+
         if (selectedTag.value == null) {
             if (favs.lastIndex < slots) emptyList()
             else favs.subList(slots, favs.size)

--- a/core/i18n/src/main/res/values/strings.xml
+++ b/core/i18n/src/main/res/values/strings.xml
@@ -1029,4 +1029,7 @@
         <item quantity="other">in %1$d minutes</item>
     </plurals>
     <string name="departure_time_departed">departed</string>
+    <string name="preference_single_tag">Set Single Tag</string>
+    <string name="preference_single_tag_summary">Show Single Tag Only</string>
+    <string name="preference_screen_select_tag">Select Tag</string>
 </resources>

--- a/core/i18n/src/main/res/values/units.xml
+++ b/core/i18n/src/main/res/values/units.xml
@@ -10,7 +10,7 @@
     <string name="dimension_volume">Volume</string>
     <string name="dimension_area">Area</string>
     <string name="dimension_currency">Currency</string>
-    <string name="dimension_data">Data</string>
+    <string name="dimension_data" translatable="false">Data</string>
     <string name="dimension_bitrate">Bitrate</string>
     <string name="dimension_pressure">Pressure</string>
     <string name="dimension_energy">Energy</string>

--- a/data/widgets/src/main/java/de/mm20/launcher2/widgets/FavoritesWidget.kt
+++ b/data/widgets/src/main/java/de/mm20/launcher2/widgets/FavoritesWidget.kt
@@ -11,6 +11,8 @@ data class FavoritesWidgetConfig(
     val editButton: Boolean = true,
     val tagsMultiline: Boolean = false,
     val compactTags: Boolean = false,
+    val singleTag: Boolean = false,
+    val singleTagValue: String = "",
 )
 
 data class FavoritesWidget(


### PR DESCRIPTION
Wanted to add a feature to this awesome launcher! This isn't quite ready yet but this is my first time diving into the code and would like some feedback/improvements.

This will allow someone to lock a single tag on the favorites widget. Currently if I select a particular tag on the Favorites Widget, it will lose that selection upon app restart or reboot. This new feature will lock it in and can be configured in the widget settings.

If this setting is on, it will also not show the edit button or any other tags in the Favorite Widget. In my opinion this looks really clean visually!

![image](https://github.com/user-attachments/assets/cb36cf52-191e-43a1-bb58-a7396c0e8ee6)
![image](https://github.com/user-attachments/assets/aedd2573-2ba2-4557-9ff9-9deed36ccafa)
