### PR TITLE
Apply `hideNav` to bottom inset padding of searchbar and clock widget

### DIFF
--- a/app/ui/src/main/java/de/mm20/launcher2/ui/assistant/AssistantScaffold.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/assistant/AssistantScaffold.kt
@@ -3,7 +3,6 @@ package de.mm20.launcher2.ui.assistant
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.*

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/PagerScaffold.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/PagerScaffold.kt
@@ -386,6 +386,8 @@ fun PagerScaffold(
         }
     }
 
+    val hideNav by viewModel.hideNavBar.collectAsState(false)
+
     val insets = WindowInsets.safeDrawing.asPaddingValues()
 
     Box(
@@ -461,7 +463,7 @@ fun PagerScaffold(
                             val clockHeight by remember {
                                 derivedStateOf {
                                     if (fillClockHeight) {
-                                        height - (64.dp + insets.calculateTopPadding() + insets.calculateBottomPadding() - clockPadding)
+                                        height - (64.dp + insets.calculateTopPadding() + (if (hideNav) 0.dp else insets.calculateBottomPadding()) - clockPadding)
                                     } else {
                                         null
                                     }
@@ -637,6 +639,7 @@ fun PagerScaffold(
             highlightedAction = searchVM.bestMatch.value as? SearchAction,
             isSearchOpen = isSearchOpen,
             darkColors = LocalPreferDarkContentOverWallpaper.current && searchBarColor == SearchBarColors.Auto || searchBarColor == SearchBarColors.Dark,
+            hideNav = hideNav,
             bottomSearchBar = bottomSearchBar,
             searchBarOffset = {
                 (if (focusSearchBar || fixedSearchBar) 0 else searchBarOffset.value.toInt() * if (bottomSearchBar) 1 else -1) +

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/PullDownScaffold.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/PullDownScaffold.kt
@@ -1,6 +1,5 @@
 package de.mm20.launcher2.ui.launcher
 
-import android.util.Log
 import android.view.HapticFeedbackConstants
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
@@ -10,7 +9,6 @@ import androidx.compose.animation.core.spring
 import androidx.compose.animation.slideIn
 import androidx.compose.animation.slideOut
 import androidx.compose.foundation.LocalOverscrollConfiguration
-import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
@@ -28,7 +26,6 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.windowInsetsPadding
-import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.pager.VerticalPager
 import androidx.compose.foundation.pager.rememberPagerState
@@ -48,7 +45,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
@@ -387,6 +383,7 @@ fun PullDownScaffold(
         }
     }
 
+    val hideNav by viewModel.hideNavBar.collectAsState(false)
     val insets = WindowInsets.safeDrawing.asPaddingValues()
     val colorSurfaceContainer = MaterialTheme.colorScheme.surfaceContainer
     val cardStyle = LocalCardStyle.current
@@ -434,16 +431,15 @@ fun PullDownScaffold(
                         0 -> {
                             val clockPadding by animateDpAsState(
                                 if (isWidgetsAtStart && fillClockHeight)
-                                    insets.calculateBottomPadding() + if (bottomSearchBar) 64.dp else 0.dp
+                                    (if (hideNav) 0.dp else insets.calculateBottomPadding()) + if (bottomSearchBar) 64.dp else 0.dp
                                 else 0.dp
-
                             )
                             val editModePadding by animateDpAsState(if (isWidgetEditMode && bottomSearchBar) 56.dp else 0.dp)
 
                             val clockHeight by remember {
                                 derivedStateOf {
                                     if (fillClockHeight) {
-                                        height - (insets.calculateTopPadding() + insets.calculateBottomPadding() - clockPadding + 56.dp)
+                                        height - (insets.calculateTopPadding() + (if (hideNav) 0.dp else insets.calculateBottomPadding()) - clockPadding + 56.dp)
                                     } else {
                                         null
                                     }
@@ -539,7 +535,7 @@ fun PullDownScaffold(
                                     ),
                                 paddingValues = PaddingValues(
                                     top = windowInsets.calculateTopPadding() + if (!bottomSearchBar) 64.dp + webSearchPadding else 8.dp,
-                                    bottom = windowInsets.calculateBottomPadding() +
+                                    bottom = (if (hideNav) 0.dp else windowInsets.calculateBottomPadding()) +
                                             keyboardFilterBarPadding +
                                             if (bottomSearchBar) 64.dp + webSearchPadding else 8.dp
                                 ),
@@ -621,6 +617,7 @@ fun PullDownScaffold(
                                 .roundToInt()
                         }
             },
+            hideNav = hideNav,
             onKeyboardActionGo = if (launchOnEnter) {
                 { searchVM.launchBestMatchOrAction(context) }
             } else null

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/SharedLauncherActivity.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/SharedLauncherActivity.kt
@@ -44,6 +44,7 @@ import de.mm20.launcher2.ui.component.NavBarEffects
 import de.mm20.launcher2.ui.gestures.GestureDetector
 import de.mm20.launcher2.ui.gestures.LocalGestureDetector
 import de.mm20.launcher2.ui.ktx.animateTo
+import de.mm20.launcher2.ui.ktx.conditional
 import de.mm20.launcher2.ui.launcher.search.SearchVM
 import de.mm20.launcher2.ui.launcher.sheets.LauncherBottomSheetManager
 import de.mm20.launcher2.ui.launcher.sheets.LauncherBottomSheets
@@ -233,8 +234,11 @@ abstract class SharedLauncherActivity(
                             SnackbarHost(
                                 snackbarHostState,
                                 modifier = Modifier
-                                    .navigationBarsPadding()
                                     .imePadding()
+                                    .conditional(
+                                        !hideNav,
+                                        Modifier.navigationBarsPadding()
+                                    )
                             )
                             enterTransition?.let {
                                 if (it.startBounds == null || it.targetBounds == null) return@let

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/searchbar/LauncherSearchBar.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/searchbar/LauncherSearchBar.kt
@@ -8,8 +8,10 @@ import androidx.compose.animation.scaleIn
 import androidx.compose.animation.scaleOut
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.imeAnimationTarget
 import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.windowInsetsPadding
@@ -18,10 +20,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.FilterAlt
 import androidx.compose.material.icons.rounded.VisibilityOff
 import androidx.compose.material3.Badge
-import androidx.compose.material3.FilledIconButton
-import androidx.compose.material3.FilledTonalIconToggleButton
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.IconToggleButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -57,6 +56,7 @@ fun LauncherSearchBar(
     onFocusChange: (Boolean) -> Unit,
     actions: List<SearchAction>,
     highlightedAction: SearchAction?,
+    hideNav: Boolean = false,
     isSearchOpen: Boolean = false,
     darkColors: Boolean = false,
     bottomSearchBar: Boolean = false,
@@ -81,11 +81,15 @@ fun LauncherSearchBar(
 
     val _value = value()
 
+    var insetSides = WindowInsetsSides.Start + WindowInsetsSides.Top + WindowInsetsSides.End
+    if (!hideNav || isSearchOpen)
+        insetSides += WindowInsetsSides.Bottom
+
     Box(modifier = modifier) {
         SearchBar(
             modifier = Modifier
                 .align(if (bottomSearchBar) Alignment.BottomCenter else Alignment.TopCenter)
-                .windowInsetsPadding(WindowInsets.safeDrawing)
+                .windowInsetsPadding(WindowInsets.safeDrawing.only(insetSides))
                 .padding(8.dp)
                 .offset { IntOffset(0, searchBarOffset()) },
             style = style, level = level(), value = _value, onValueChange = {


### PR DESCRIPTION
Closes #381 

As described in that issue, when `hideNav` is enabled, anytime you'd return to the home screen the clock widget & searchbar would shortly "jerk" upwards as to make room for the navigation bar, which would then instantly disappear again, for the UI to jerk back down again. Turns out that it has been the `WindowInsets.safeDrawing` padding values... 

I've worked around that, not sure if that's the way how it is supposed to be done, but it definetly fixes this bug which has been bugging and secretly driving me insane since I started using this awesome launcher, so: plz merge fast :b