### PR TITLE
Add background color to blur

### DIFF
--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/scaffold/LauncherScaffold.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/scaffold/LauncherScaffold.kt
@@ -101,6 +101,7 @@ import de.mm20.launcher2.ui.launcher.search.SearchVM
 import de.mm20.launcher2.ui.launcher.search.filters.KeyboardFilterBar
 import de.mm20.launcher2.ui.launcher.searchbar.LauncherSearchBar
 import de.mm20.launcher2.ui.theme.transparency.LocalTransparencyScheme
+import dev.chrisbanes.haze.HazeTint
 import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState
@@ -1514,6 +1515,7 @@ internal fun LauncherScaffold(
                     .fillMaxWidth()
                     .hazeEffect(hazeState) {
                         blurRadius = 4.dp
+                        backgroundColor = config.backgroundColor
                     }
                     .background(
                         MaterialTheme.colorScheme.surfaceContainer.copy(alpha = LocalTransparencyScheme.current.background)
@@ -1534,6 +1536,7 @@ internal fun LauncherScaffold(
                     .fillMaxWidth()
                     .hazeEffect(hazeState) {
                         blurRadius = 4.dp
+                        backgroundColor = config.backgroundColor
                     }
                     .background(
                         MaterialTheme.colorScheme.surfaceContainer.copy(alpha = LocalTransparencyScheme.current.background)

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/scaffold/LauncherScaffold.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/scaffold/LauncherScaffold.kt
@@ -101,7 +101,6 @@ import de.mm20.launcher2.ui.launcher.search.SearchVM
 import de.mm20.launcher2.ui.launcher.search.filters.KeyboardFilterBar
 import de.mm20.launcher2.ui.launcher.searchbar.LauncherSearchBar
 import de.mm20.launcher2.ui.theme.transparency.LocalTransparencyScheme
-import dev.chrisbanes.haze.HazeTint
 import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState


### PR DESCRIPTION
Currently the navbar blur has quite a lot of artifacts, especially around the edges of the screen (it also doesn't blur the background). The added background fixes the artifacts, however it also ignores the background, so it's kinda a sidegrade. Still, I think it look a bit less annoying.