### PR TITLE
Reduce calendar refreshes

### DIFF
--- a/data/calendar/src/main/java/de/mm20/launcher2/calendar/CalendarRepository.kt
+++ b/data/calendar/src/main/java/de/mm20/launcher2/calendar/CalendarRepository.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.combineTransform
+import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
@@ -120,7 +121,7 @@ internal class CalendarRepositoryImpl(
                     excludeCalendars = excludeCalendars,
                     providers = providers,
                     allowNetwork = false,
-                )
+                ).debounce(500)
             )
         }
     }


### PR DESCRIPTION
Currently the calendar widget logic pushes retrieved events as soon as possible instead of aggregating the results and pushing them at once. Since it's impossible for all results to come back at the same time, for the few frames that it takes for all the results to come back the widget bops around.

How that issue looks right now: 
https://github.com/user-attachments/assets/929d0eb4-fab7-4e5a-b095-a0d6070832c7

By waiting for all the results to come in we can avoid that.

Also, since this happens every time you go home/press the home button, I'd like to imagine that this also saves a couple of wasted redraws :Dd