### PR TITLE
Music widget displays hours and days if applicable

### DIFF
--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/widgets/music/MusicWidget.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/widgets/music/MusicWidget.kt
@@ -530,9 +530,19 @@ fun NoData() {
     }
 }
 
+@Suppress("DefaultLocale")
 private fun formatTimestamp(timestamp: Long?): String {
     if (timestamp == null) return "--:--"
-    val minutes = timestamp / 1000 / 60
-    val seconds = timestamp / 1000 % 60
-    return String.format("%02d:%02d", minutes, seconds)
+
+    val totalSeconds = timestamp / 1000
+    val days = totalSeconds / 86_400
+    val hours = (totalSeconds % 86_400) / 3600
+    val minutes = (totalSeconds % 3600) / 60
+    val seconds = totalSeconds % 60
+
+    return when {
+        days > 0 -> String.format("%d:%02d:%02d:%02d", days, hours, minutes, seconds)
+        hours > 0 -> String.format("%d:%02d:%02d", hours, minutes, seconds)
+        else -> String.format("%02d:%02d", minutes, seconds)
+    }
 }


### PR DESCRIPTION
This PR updates the media/music widget to support displaying durations in hours or days if needed, resolving #1043.

formatTimestamp() now uses `D:HH:MM:SS`, `H:MM:SS`, or `MM:SS` depending on the duration.

I've tested it against videos of various durations and the formatting appears to work correctly in all cases.

![image](https://github.com/user-attachments/assets/4d9a186f-1925-4b58-93b0-6d63ff9cd94e)