### PR TITLE
Add dock rows setting to choose how many rows to display

### DIFF
--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/widgets/clock/parts/FavoritesPartProvider.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/widgets/clock/parts/FavoritesPartProvider.kt
@@ -38,15 +38,16 @@ class FavoritesPartProvider : PartProvider, KoinComponent {
                 it.columnCount
             }
         }.collectAsState(0)
+        val dockRows by uiSettings.dockRows.collectAsState(1)
         val excludeCalendar by remember { widgetRepository.exists(CalendarWidget.Type) }.collectAsState(
             true
         )
 
-        val favorites by remember(columns, excludeCalendar) {
+        val favorites by remember(columns, dockRows, excludeCalendar) {
             favoritesService.getFavorites(
                 excludeTypes = if (excludeCalendar) listOf("calendar", "tag") else listOf("tag"),
                 minPinnedLevel = PinnedLevel.FrequentlyUsed,
-                limit = columns
+                limit = columns * dockRows
             )
         }.collectAsState(emptyList())
 

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/settings/homescreen/HomescreenSettingsScreen.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/settings/homescreen/HomescreenSettingsScreen.kt
@@ -75,6 +75,7 @@ fun HomescreenSettingsScreen() {
     val context = LocalContext.current
 
     val dock by viewModel.dock.collectAsStateWithLifecycle(null)
+    val dockRows by viewModel.dockRows.collectAsStateWithLifecycle(1)
     val fixedRotation by viewModel.fixedRotation.collectAsStateWithLifecycle(null)
     val widgetsOnHomeScreen by viewModel.widgetsOnHomeScreen.collectAsStateWithLifecycle(null)
     val editButton by viewModel.widgetEditButton.collectAsStateWithLifecycle(null)
@@ -123,6 +124,17 @@ fun HomescreenSettingsScreen() {
                         viewModel.setDock(it)
                     },
                 )
+                AnimatedVisibility(dock == true) {
+                    SliderPreference(
+                        title = stringResource(R.string.preference_clockwidget_dock_rows),
+                        value = dockRows,
+                        min = 1,
+                        max = 4,
+                        onValueChanged = {
+                            viewModel.setDockRows(it)
+                        }
+                    )
+                }
                 SwitchPreference(
                     title = stringResource(R.string.preference_widgets_on_home_screen),
                     summary = stringResource(R.string.preference_widgets_on_home_screen_summary),

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/settings/homescreen/HomescreenSettingsScreenVM.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/settings/homescreen/HomescreenSettingsScreenVM.kt
@@ -131,6 +131,13 @@ class HomescreenSettingsScreenVM(
         uiSettings.setDock(dock)
     }
 
+    val dockRows = uiSettings.dockRows
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), 1)
+
+    fun setDockRows(rows: Int) {
+        uiSettings.setDockRows(rows)
+    }
+
     val fixedRotation = uiSettings.orientation.map { it != ScreenOrientation.Auto }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), null)
 

--- a/core/i18n/src/main/res/values-de/strings.xml
+++ b/core/i18n/src/main/res/values-de/strings.xml
@@ -322,7 +322,8 @@
     <string name="preference_search_appshortcuts_summary">App-Shortcuts durchsuchen</string>
     <string name="widget_name_favorites">Favoriten</string>
     <string name="preference_clockwidget_favorites_part">Dock</string>
-    <string name="preference_clockwidget_favorites_part_summary">Die erste Zeile der Favoriten anzeigen</string>
+    <string name="preference_clockwidget_favorites_part_summary">Favoriten im Dock anzeigen</string>
+    <string name="preference_clockwidget_dock_rows">Dock-Zeilen</string>
     <string name="preference_grid_icon_size">Symbolgröße</string>
     <string name="preference_search_currencyconverter">Währungsumrechner</string>
     <string name="preference_search_currencyconverter_summary">Regelmäßig Wechselkurse herunterladen um Währungen umzurechnen</string>

--- a/core/i18n/src/main/res/values/strings.xml
+++ b/core/i18n/src/main/res/values/strings.xml
@@ -597,7 +597,8 @@
     <string name="preference_clockwidget_date_part">Date</string>
     <string name="preference_clockwidget_date_part_summary">Show the current date</string>
     <string name="preference_clockwidget_favorites_part">Dock</string>
-    <string name="preference_clockwidget_favorites_part_summary">Show the first row of pinned items</string>
+    <string name="preference_clockwidget_favorites_part_summary">Show pinned items in dock</string>
+    <string name="preference_clockwidget_dock_rows">Dock rows</string>
     <string name="preference_clockwidget_music_part">Media</string>
     <string name="preference_clockwidget_music_part_summary">Show media controls when there is an active media session</string>
     <string name="preference_clockwidget_battery_part">Battery</string>

--- a/core/preferences/src/main/java/de/mm20/launcher2/preferences/LauncherSettingsData.kt
+++ b/core/preferences/src/main/java/de/mm20/launcher2/preferences/LauncherSettingsData.kt
@@ -56,6 +56,7 @@ data class LauncherSettingsData internal constructor(
     val clockWidgetAlignment: ClockWidgetAlignment = ClockWidgetAlignment.Bottom,
 
     val homeScreenDock: Boolean = false,
+    val homeScreenDockRows: Int = 1,
     val homeScreenWidgets: Boolean = false,
 
     val favoritesEnabled: Boolean = true,

--- a/core/preferences/src/main/java/de/mm20/launcher2/preferences/ui/UiSettings.kt
+++ b/core/preferences/src/main/java/de/mm20/launcher2/preferences/ui/UiSettings.kt
@@ -357,6 +357,17 @@ class UiSettings internal constructor(
         }
     }
 
+    val dockRows
+        get() = launcherDataStore.data.map {
+            it.homeScreenDockRows
+        }.distinctUntilChanged()
+
+    fun setDockRows(rows: Int) {
+        launcherDataStore.update {
+            it.copy(homeScreenDockRows = rows)
+        }
+    }
+
     val homeScreenWidgets
         get() = launcherDataStore.data.map {
             it.homeScreenWidgets


### PR DESCRIPTION
Implements #1415 

This change lets the user configure the amount of rows to show in the dock from 1 to 4, instead of just showing the first one.

Added a setting for it:
<img width="482" height="1062" alt="grafik" src="https://github.com/user-attachments/assets/85bd4cd3-8e3d-41b7-8942-6b7dd8a278ec" />

On the home screen:
<img width="482" height="1062" alt="grafik" src="https://github.com/user-attachments/assets/6e63f819-4a63-484c-9350-745a4d03b89b" />
