### PR TITLE
Update: Add date display to weather forecast daily widget

### DIFF
--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/widgets/weather/WeatherWidget.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/widgets/weather/WeatherWidget.kt
@@ -537,7 +537,7 @@ fun WeatherDaySelector(
     onDaySelected: (Int) -> Unit,
     imperialUnits: Boolean
 ) {
-    val dateFormat = SimpleDateFormat("EEE")
+    val dateFormat = SimpleDateFormat("EEE, d")
 
     val listState = rememberLazyListState()
     LazyRow(
@@ -578,7 +578,7 @@ fun WeatherDaySelector(
                     WeatherIcon(icon = weatherIconById(day.icon))
                     Text(
                         modifier = Modifier.padding(start = 8.dp),
-                        text = "${dateFormat.format(day.timestamp)} " +
+                        text = "${dateFormat.format(day.timestamp)} - " +
                                 "${convertTemperature(imperialUnits, day.minTemp)}° / " +
                                 "${convertTemperature(imperialUnits, day.maxTemp)}°",
                         softWrap = false,


### PR DESCRIPTION
This pull request adds the date display alongside the day in the weather forecast widget.

Previously, only the day name (e.g., "Mon") was shown, which could cause confusion when trying to track forecasts over multiple days

By including the date, it improves clarity and usability of the forecast feature (see attached a screenshot showing the updated widget layout. The location information has been removed from the image to avoid including doxxing details)

<img width="390" height="800" alt="image" src="https://github.com/user-attachments/assets/2f8696a5-4ece-4cc3-89ef-c0fb08158429" />
