### PR TITLE
Center "edit widgets" button

### DIFF
--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/widgets/WidgetColumn.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/widgets/WidgetColumn.kt
@@ -66,7 +66,7 @@ fun WidgetColumn(
 
 
     Column(
-        modifier = modifier
+        modifier = modifier.fillMaxWidth()
     ) {
         val scope = rememberCoroutineScope()
         Column {


### PR DESCRIPTION
If there are no widgets, the "add widgets" button is not centrally aligned.