### PR TITLE
Add option to use monospaced digits in the clock widget

### DIFF
--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/widgets/clock/ClockWidget.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/widgets/clock/ClockWidget.kt
@@ -27,6 +27,7 @@ import androidx.compose.material.icons.rounded.AutoAwesome
 import androidx.compose.material.icons.rounded.BatteryFull
 import androidx.compose.material.icons.rounded.ColorLens
 import androidx.compose.material.icons.rounded.DarkMode
+import androidx.compose.material.icons.rounded.FormatColorText
 import androidx.compose.material.icons.rounded.Height
 import androidx.compose.material.icons.rounded.HorizontalSplit
 import androidx.compose.material.icons.rounded.LightMode
@@ -272,6 +273,7 @@ fun Clock(
     val context = LocalContext.current
     val clockSettings: ClockWidgetSettings = koinInject()
     val showSeconds by clockSettings.showSeconds.collectAsState(initial = false)
+    val monospaced by clockSettings.monospaced.collectAsState(initial = false)
     val useThemeColor by clockSettings.useThemeColor.collectAsState(initial = false)
     val timeFormat by clockSettings.timeFormat.collectAsState(null)
 
@@ -285,6 +287,7 @@ fun Clock(
             compact = compact,
             showSeconds = showSeconds,
             twentyFourHours = isTwentyFourHours,
+            monospaced = monospaced,
             useThemeColor = useThemeColor,
             darkColors = darkColors,
             style = style,
@@ -295,6 +298,7 @@ fun Clock(
             compact = compact,
             showSeconds = showSeconds,
             twentyFourHours = isTwentyFourHours,
+            monospaced = monospaced,
             useThemeColor = useThemeColor,
             darkColors = darkColors,
         )
@@ -322,6 +326,7 @@ fun Clock(
             compact = compact,
             showSeconds = showSeconds,
             twentyFourHours = isTwentyFourHours,
+            monospaced = monospaced,
             useThemeColor = useThemeColor,
             darkColors = darkColors,
         )
@@ -366,6 +371,7 @@ fun ConfigureClockWidgetSheet(
     val widgetsOnHome by viewModel.widgetsOnHome.collectAsState()
     val alignment by viewModel.alignment.collectAsState()
     val showSeconds by viewModel.showSeconds.collectAsState()
+    val monospaced by viewModel.monospaced.collectAsState()
     val timeFormat by viewModel.timeFormat.collectAsState()
     val useAccentColor by viewModel.useThemeColor.collectAsState()
     val parts by viewModel.parts.collectAsState()
@@ -510,6 +516,20 @@ fun ConfigureClockWidgetSheet(
                             value = showSeconds,
                             onValueChanged = {
                                 viewModel.setShowSeconds(it)
+                            }
+                        )
+                    }
+                    AnimatedVisibility(
+                        style is ClockWidgetStyle.Digital1 ||
+                                style is ClockWidgetStyle.Digital2 ||
+                                style is ClockWidgetStyle.Orbit
+                    ) {
+                        SwitchPreference(
+                            title = stringResource(R.string.preference_clock_widget_monospaced),
+                            icon = Icons.Rounded.FormatColorText,
+                            value = monospaced,
+                            onValueChanged = {
+                                viewModel.setMonospaced(it)
                             }
                         )
                     }

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/widgets/clock/clocks/DigitalClock1.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/widgets/clock/clocks/DigitalClock1.kt
@@ -35,6 +35,7 @@ fun DigitalClock1(
     compact: Boolean,
     twentyFourHours: Boolean,
     showSeconds: Boolean,
+    monospaced: Boolean,
     useThemeColor: Boolean,
     darkColors: Boolean,
 ) {
@@ -75,6 +76,7 @@ fun DigitalClock1(
     val textStyle = MaterialTheme.typography.displayLarge.copy(
         fontSize = if (verticalLayout) 100.sp else 48.sp,
         fontWeight = FontWeight.Black,
+        fontFeatureSettings = if (monospaced) "tnum" else null,
         textAlign = TextAlign.Center,
         lineHeight = 0.8.em,
         drawStyle = if (style.outlined) Stroke(width = 2.dp.toPixels()) else Fill,

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/widgets/clock/clocks/DigitalClock2.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/widgets/clock/clocks/DigitalClock2.kt
@@ -22,6 +22,7 @@ fun DigitalClock2(
     compact: Boolean,
     showSeconds: Boolean,
     twentyFourHours: Boolean,
+    monospaced: Boolean,
     useThemeColor: Boolean,
     darkColors: Boolean,
 ) {
@@ -64,6 +65,7 @@ fun DigitalClock2(
         text = formatter.format(time),
         style = MaterialTheme.typography.displaySmall.copy(
             fontWeight = FontWeight.Normal,
+            fontFeatureSettings = if (monospaced) "tnum" else null,
             color = color
         )
     )

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/widgets/clock/clocks/OrbitClock.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/widgets/clock/clocks/OrbitClock.kt
@@ -49,6 +49,7 @@ fun OrbitClock(
     compact: Boolean,
     showSeconds: Boolean,
     twentyFourHours: Boolean,
+    monospaced: Boolean,
     useThemeColor: Boolean,
     darkColors: Boolean,
 ) {
@@ -126,8 +127,12 @@ fun OrbitClock(
     val contentColor = LocalContentColor.current
 
     val textMeasurer = rememberTextMeasurer()
-    val minuteStyle = MaterialTheme.typography.labelMedium
-    val hourStyle = MaterialTheme.typography.labelLarge
+    val minuteStyle = MaterialTheme.typography.labelMedium.copy(
+        fontFeatureSettings = if (monospaced) "tnum" else null
+    )
+    val hourStyle = MaterialTheme.typography.labelLarge.copy(
+        fontFeatureSettings = if (monospaced) "tnum" else null
+    )
 
     val strokeWidth = if (verticalLayout) 2.dp else 1.dp
 

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/settings/clockwidget/ClockWidgetSettingsScreenVM.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/settings/clockwidget/ClockWidgetSettingsScreenVM.kt
@@ -57,6 +57,13 @@ class ClockWidgetSettingsScreenVM : ViewModel(), KoinComponent {
         settings.setShowSeconds(showSeconds)
     }
 
+    val monospaced = settings.monospaced
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), false)
+
+    fun setMonospaced(monospaced: Boolean) {
+        settings.setMonospaced(monospaced)
+    }
+
     val timeFormat = settings.timeFormat
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), TimeFormat.System)
 

--- a/core/i18n/src/main/res/values/strings.xml
+++ b/core/i18n/src/main/res/values/strings.xml
@@ -583,6 +583,7 @@
     <string name="preference_clockwidget_layout_vertical">Default</string>
     <string name="preference_clockwidget_layout_horizontal">Compact</string>
     <string name="preference_clock_widget_show_seconds">Show seconds</string>
+    <string name="preference_clock_widget_monospaced">Monospaced digits</string>
     <string name="preference_clock_widget_time_format">Time format</string>
     <string name="preference_clock_widget_time_format_24h">24-hour</string>
     <string name="preference_clock_widget_time_format_12h">12-hour</string>

--- a/core/preferences/src/main/java/de/mm20/launcher2/preferences/LauncherSettingsData.kt
+++ b/core/preferences/src/main/java/de/mm20/launcher2/preferences/LauncherSettingsData.kt
@@ -45,6 +45,7 @@ data class LauncherSettingsData internal constructor(
     val clockWidgetCustom: ClockWidgetStyle.Custom = ClockWidgetStyle.Custom(),
     val clockWidgetColors: ClockWidgetColors = ClockWidgetColors.Auto,
     val clockWidgetShowSeconds: Boolean = false,
+    val clockWidgetMonospaced: Boolean = false,
     val clockWidgetTimeFormat: TimeFormat = TimeFormat.System,
     val clockWidgetUseThemeColor: Boolean = false,
     val clockWidgetAlarmPart: Boolean = true,

--- a/core/preferences/src/main/java/de/mm20/launcher2/preferences/ui/ClockWidgetSettings.kt
+++ b/core/preferences/src/main/java/de/mm20/launcher2/preferences/ui/ClockWidgetSettings.kt
@@ -136,6 +136,15 @@ class ClockWidgetSettings internal constructor(
         }
     }
 
+    val monospaced
+        get() = launcherDataStore.data.map { it.clockWidgetMonospaced }
+
+    fun setMonospaced(enabled: Boolean) {
+        launcherDataStore.update {
+            it.copy(clockWidgetMonospaced = enabled)
+        }
+    }
+
     val timeFormat
         get() = launcherDataStore.data.map { it.clockWidgetTimeFormat }
 


### PR DESCRIPTION
Currently, if the digits of the clock's font have different widths, they jump around when the time changes.
This pr adds an option to prevent this.

Example (disabled/enabled):

<img width="270" height="600" alt="Screenshot_20250817_150613" src="https://github.com/user-attachments/assets/a4a0c138-337d-4ec9-b381-83a29e4cb605" />
<img width="270" height="600" alt="Screenshot_20250817_150520" src="https://github.com/user-attachments/assets/2bba8982-66e4-45ec-b601-fea274ef029c" />
