### PR TITLE
Feature: Convert lower cased currency codes in unit conversion

### DIFF
--- a/data/unitconverter/src/main/java/de/mm20/launcher2/unitconverter/converters/CurrencyConverter.kt
+++ b/data/unitconverter/src/main/java/de/mm20/launcher2/unitconverter/converters/CurrencyConverter.kt
@@ -28,7 +28,7 @@ class CurrencyConverter(
     private val topCurrencies = arrayOf("USD", "EUR", "JPY", "GBP", "AUD")
 
     override suspend fun isValidUnit(symbol: String): Boolean {
-        return repository.isValidCurrency(symbol)
+        return repository.isValidCurrency(symbol.uppercase())
     }
 
 
@@ -76,7 +76,7 @@ class CurrencyConverter(
         value: Double,
         toUnit: String?
     ): UnitConverter {
-        val fromIsoCode = repository.resolveAlias(fromUnit)
+        val fromIsoCode = repository.resolveAlias(fromUnit.uppercase())
         val toIsoCode = toUnit?.let { repository.resolveAlias(it) }
 
         val values = repository.convertCurrency(fromIsoCode, value, toIsoCode).map {


### PR DESCRIPTION
Currently only fully upper cased currency codes (USD, INR, etc.) show currency conversion results in search. This change allows lower cased currency codes (usd, inr, etc.) to show currency conversion results as well.

I know this is a tiny change but it was really bugging me out 😅