### PR TITLE
Fix Samsung widgets not working

### DIFF
--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/widgets/external/AppWidgetHost.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/widgets/external/AppWidgetHost.kt
@@ -1,6 +1,5 @@
 package de.mm20.launcher2.ui.launcher.widgets.external
 
-import android.appwidget.AppWidgetManager
 import android.appwidget.AppWidgetProviderInfo
 import android.os.Build
 import android.os.Bundle


### PR DESCRIPTION
Apparently Samsung really wants `OPTION_APPWIDGET_SIZES` to be set.

Fixes #1413