### PR TITLE
Reset music widget when nothing is playing

### DIFF
--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/widgets/music/MusicWidget.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/widgets/music/MusicWidget.kt
@@ -120,8 +120,8 @@ fun MusicWidget(widget: MusicWidget) {
                 }
             )
         }
-        if (title == null && artist == null) {
-            NoData()
+        if (title == null && artist == null || playbackState == PlaybackState.Stopped) {
+            NotPlaying()
         } else {
             Row(
                 modifier = Modifier.height(IntrinsicSize.Min)
@@ -318,77 +318,77 @@ fun MusicWidget(widget: MusicWidget) {
                     }
                 }
             }
-        }
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 16.dp),
-            horizontalArrangement = Arrangement.SpaceAround,
-            verticalAlignment = Alignment.CenterVertically,
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 16.dp),
+                horizontalArrangement = Arrangement.SpaceAround,
+                verticalAlignment = Alignment.CenterVertically,
 
-            ) {
-            if (supportedActions.skipToPrevious) {
-                Tooltip(
-                    tooltipText = stringResource(R.string.music_widget_previous_track)
                 ) {
-                    IconButton(
-                        onClick = {
-                            viewModel.skipPrevious()
-                        }) {
-                        Icon(
-                            imageVector = Icons.Rounded.SkipPrevious,
-                            stringResource(R.string.music_widget_previous_track)
-                        )
+                if (supportedActions.skipToPrevious) {
+                    Tooltip(
+                        tooltipText = stringResource(R.string.music_widget_previous_track)
+                    ) {
+                        IconButton(
+                            onClick = {
+                                viewModel.skipPrevious()
+                            }) {
+                            Icon(
+                                imageVector = Icons.Rounded.SkipPrevious,
+                                stringResource(R.string.music_widget_previous_track)
+                            )
+                        }
                     }
                 }
-            }
-            val playPauseIcon =
-                AnimatedImageVector.animatedVectorResource(R.drawable.anim_ic_play_pause)
-            Tooltip(
-                tooltipText = stringResource(
-                    if (playbackState == PlaybackState.Playing) R.string.music_widget_pause
-                    else R.string.music_widget_play
-                )
-            ) {
-                FilledTonalIconButton(
-                    colors = IconButtonDefaults.filledTonalIconButtonColors(
-                        containerColor = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = MaterialTheme.transparency.surface),
-                    ),
-                    onClick = { viewModel.togglePause() },
-                ) {
-                    Icon(
-                        painter = rememberAnimatedVectorPainter(
-                            playPauseIcon,
-                            atEnd = playbackState == PlaybackState.Playing
-                        ),
-                        contentDescription = stringResource(
-                            if (playbackState == PlaybackState.Playing) R.string.music_widget_pause
-                            else R.string.music_widget_play
-                        )
+                val playPauseIcon =
+                    AnimatedImageVector.animatedVectorResource(R.drawable.anim_ic_play_pause)
+                Tooltip(
+                    tooltipText = stringResource(
+                        if (playbackState == PlaybackState.Playing) R.string.music_widget_pause
+                        else R.string.music_widget_play
                     )
-                }
-            }
-            if (supportedActions.skipToNext) {
-                Tooltip(
-                    tooltipText = stringResource(R.string.music_widget_next_track)
                 ) {
-                    IconButton(onClick = {
-                        viewModel.skipNext()
-                    }) {
+                    FilledTonalIconButton(
+                        colors = IconButtonDefaults.filledTonalIconButtonColors(
+                            containerColor = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = MaterialTheme.transparency.surface),
+                        ),
+                        onClick = { viewModel.togglePause() },
+                    ) {
                         Icon(
-                            imageVector = Icons.Rounded.SkipNext,
-                            stringResource(R.string.music_widget_next_track)
+                            painter = rememberAnimatedVectorPainter(
+                                playPauseIcon,
+                                atEnd = playbackState == PlaybackState.Playing
+                            ),
+                            contentDescription = stringResource(
+                                if (playbackState == PlaybackState.Playing) R.string.music_widget_pause
+                                else R.string.music_widget_play
+                            )
                         )
                     }
                 }
+                if (supportedActions.skipToNext) {
+                    Tooltip(
+                        tooltipText = stringResource(R.string.music_widget_next_track)
+                    ) {
+                        IconButton(onClick = {
+                            viewModel.skipNext()
+                        }) {
+                            Icon(
+                                imageVector = Icons.Rounded.SkipNext,
+                                stringResource(R.string.music_widget_next_track)
+                            )
+                        }
+                    }
+                }
+                CustomActions(
+                    actions = supportedActions,
+                    onActionSelected = {
+                        viewModel.performCustomAction(it)
+                    },
+                    playerPackage = viewModel.currentPlayerPackage,
+                )
             }
-            CustomActions(
-                actions = supportedActions,
-                onActionSelected = {
-                    viewModel.performCustomAction(it)
-                },
-                playerPackage = viewModel.currentPlayerPackage,
-            )
         }
     }
 }
@@ -508,7 +508,7 @@ fun CustomActionIcon(action: CustomAction, playerPackage: String?) {
 }
 
 @Composable
-fun NoData() {
+fun NotPlaying() {
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -524,7 +524,7 @@ fun NoData() {
             tint = MaterialTheme.colorScheme.secondary
         )
         Text(
-            text = stringResource(id = R.string.music_widget_no_data),
+            text = stringResource(id = R.string.music_widget_not_playing),
             style = MaterialTheme.typography.bodySmall
         )
     }

--- a/core/i18n/src/main/res/values-fr/strings.xml
+++ b/core/i18n/src/main/res/values-fr/strings.xml
@@ -315,6 +315,7 @@
     <string name="preference_wikipedia_customurl">URL Wikipédia</string>
     <string name="music_widget_default_title">%1$s joue un média</string>
     <string name="music_widget_no_data">Aucun média n\'a encore été joué</string>
+    <string name="music_widget_not_playing">Aucun média en cours de lecture</string>
     <string name="no_account_nextcloud">Vous n\'avez pas connecté de compte Nextcloud pour le moment</string>
     <string name="no_account_owncloud">Vous n\'avez pas connecté de compte Owncloud pour le moment</string>
     <string name="connect_account">Connecter un compte</string>

--- a/core/i18n/src/main/res/values/strings.xml
+++ b/core/i18n/src/main/res/values/strings.xml
@@ -324,6 +324,7 @@
     <string name="task_due_today">Due today</string>
     <!-- Default title that is shown in the music widget if the app that is playing media did not publish a title -->
     <string name="music_widget_default_title">%1$s is playing media</string>
+    <string name="music_widget_not_playing">No media currently playing</string>
     <string name="music_widget_no_data">No media has been played yet</string>
     <string name="music_widget_interactive_progress_bar">Interactive progress bar</string>
     <string name="weather_condition_sleetshowers">Sleet showers</string>


### PR DESCRIPTION
This PR resets the music widget when nothing is playing.

<img width="240" alt="Screenshot_20251007-120927" src="https://github.com/user-attachments/assets/83259834-084f-4d78-afe5-4179bac08c13" />

I changed the translation key related to the player state. I did not remove the previous one (I'm not sure how to do it properly).

I also hid the player controls in this screen. Before that, when no music was known, it would show the play, previous and next buttons.