### PR TITLE
Fix: Resolve selectable apps bug in MediaIntegrationSettings

### DIFF
--- a/app/ui/src/main/java/de/mm20/launcher2/ui/settings/media/MediaIntegrationSettingsScreen.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/settings/media/MediaIntegrationSettingsScreen.kt
@@ -35,6 +35,7 @@ fun MediaIntegrationSettingsScreen() {
     val viewModel: MediaIntegrationSettingsScreenVM = viewModel()
     val hasPermission by viewModel.hasPermission.collectAsStateWithLifecycle(null)
     val loading by viewModel.loading
+    val appList by viewModel.appList
 
     val density = LocalDensity.current
 
@@ -57,37 +58,41 @@ fun MediaIntegrationSettingsScreen() {
                 )
             }
         }
-        item {
-            MissingPermissionBanner(
-                text = stringResource(R.string.missing_permission_music_widget),
-                onClick = {
-                    viewModel.requestNotificationPermission(context as AppCompatActivity)
-                },
-                modifier = Modifier
-                    .background(
-                        MaterialTheme.colorScheme.surface,
-                        MaterialTheme.shapes.medium
-                    )
-                    .padding(16.dp)
-            )
-            PreferenceCategory(
-                stringResource(R.string.preference_category_media_apps)
-            ) {
-                val apps by viewModel.appList
-                for (app in apps) {
-                    val icon by app.icon.collectAsState(null)
-                    CheckboxPreference(
-                        icon = {
-                            ShapedLauncherIcon(size = 32.dp, icon = { icon })
-                        },
-                        title = app.label,
-                        value = app.isChecked,
-                        onValueChanged = {
-                            viewModel.onAppChecked(app, it)
-                        }
-                    )
-                }
+        if (hasPermission == false) {
+            item {
+                MissingPermissionBanner(
+                    text = stringResource(R.string.missing_permission_music_widget),
+                    onClick = {
+                        viewModel.requestNotificationPermission(context as AppCompatActivity)
+                    },
+                    modifier = Modifier
+                        .background(
+                            MaterialTheme.colorScheme.surface,
+                            MaterialTheme.shapes.medium
+                        )
+                        .padding(16.dp)
+                )
             }
+        }
+        item {
+            PreferenceCategory(stringResource(R.string.preference_category_media_apps)) {}
+        }
+        items(
+            count = appList.size,
+            key = { index -> appList[index].packageName }
+        ) { index ->
+            val app = appList[index]
+            val icon by app.icon.collectAsState(null)
+            CheckboxPreference(
+                icon = {
+                    ShapedLauncherIcon(size = 32.dp, icon = { icon })
+                },
+                title = app.label,
+                value = app.isChecked,
+                onValueChanged = { newValue ->
+                    viewModel.onAppChecked(app, newValue)
+                }
+            )
         }
         if (BuildConfig.DEBUG) {
             item {


### PR DESCRIPTION
As I mentioned in the help channel
>  Somehow I can't add a media player to the integration, I see it listed but I cannot select it, played with it a little bit and found out that I can select a top X of the list (down to the letter E) but not beyond that point. I didn't count it but looks like a limit. Does anyone have the same problem?

This PR is to fix that issue.

Please consider my zero Kotlin knowledge prior this PR. (gradle and android-sdk... it's an exercise of patience)