### PR TITLE
Fix: Add back pinned tags to apps widget

### DIFF
--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/sheets/ConfigureWidgetSheet.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/sheets/ConfigureWidgetSheet.kt
@@ -511,7 +511,7 @@ fun ColumnScope.ConfigureFavoritesWidget(
                                 }
                             )
                             SwitchPreference(
-                                title = stringResource(R.string.customize_item_tags),
+                                title = stringResource(R.string.preference_compact_tags),
                                 iconPadding = false,
                                 value = widget.config.compactTags,
                                 onValueChanged = {

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/widgets/favorites/AppsWidget.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/widgets/favorites/AppsWidget.kt
@@ -50,7 +50,7 @@ fun AppsWidget(widget: AppsWidget) {
                 icon = if (selectedTag == null) R.drawable.star_24px else R.drawable.tag_24px,
             )
         }
-        if (favoritesEditButton || (customTags && widget.config.tagList.size > 1)) {
+        if (favoritesEditButton || (!customTags && pinnedTags.isNotEmpty()) || (customTags && widget.config.tagList.size > 1)) {
             FavoritesTagSelector(
                 tags = if (customTags) widget.config.tagList.map { Tag(it) } else pinnedTags,
                 selectedTag = selectedTag,


### PR DESCRIPTION
In version `1.39.1-fdroid` the pinned tags does not appear on the apps widget anymore when it is used with the favorites and the edit button is disabled. This change is intended to fix this behavior.

While I was fixing the issue above I found that the `Tags` button on the `Favorites` tab in the configuration of the apps widget is basically the same as the `Compact tags` button on the `Tags` tab. Since the text "Tags" is somewhat misleading, I changed it to "Compact tags".