### PR TITLE
Fix status bar and nav bar scrims to show only blurred wallpaper

### DIFF
--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/scaffold/LauncherScaffold.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/scaffold/LauncherScaffold.kt
@@ -31,6 +31,7 @@ import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.displayCutout
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.imeAnimationSource
 import androidx.compose.foundation.layout.imeAnimationTarget
@@ -291,7 +292,6 @@ internal class LauncherScaffoldState(
     val darkStatusBarIcons by derivedStateOf {
         val isLightBackground = config.backgroundColor.luminance() > 0.5f
         when {
-            statusBarScrim -> isLightBackground
             currentProgress < 0.5f && !config.homeComponent.drawBackground -> {
                 config.darkStatusBarIcons
             }
@@ -308,7 +308,6 @@ internal class LauncherScaffoldState(
     val darkNavBarIcons by derivedStateOf {
         val isLightBackground = config.backgroundColor.luminance() > 0.5f
         when {
-            navBarScrim -> isLightBackground
             currentProgress < 0.5f && !config.homeComponent.drawBackground -> {
                 config.darkNavBarIcons
             }
@@ -1285,6 +1284,7 @@ internal fun LauncherScaffold(
                 if (state.currentProgress >= 0.5f && (state.currentComponent?.drawBackground
                         ?: config.homeComponent.drawBackground)
                     || state.currentProgress < 0.5f && config.homeComponent.drawBackground
+                    || state.currentProgress < 0.5f && config.homeComponent.isAtTop.value == false
                 ) {
                     8.dp.toPixels().toInt()
                 } else {
@@ -1551,6 +1551,9 @@ internal fun LauncherScaffold(
         }
 
 
+        val statusBarHeight = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
+        val navBarHeight = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+
         AnimatedVisibility(
             state.statusBarScrim,
             enter = fadeIn(),
@@ -1562,14 +1565,10 @@ internal fun LauncherScaffold(
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
+                    .height(statusBarHeight)
                     .hazeEffect(hazeState) {
                         blurRadius = 4.dp
-                        backgroundColor = config.backgroundColor
                     }
-                    .background(
-                        MaterialTheme.colorScheme.surfaceContainer.copy(alpha = MaterialTheme.transparency.background)
-                    )
-                    .statusBarsPadding()
             )
         }
         AnimatedVisibility(
@@ -1583,14 +1582,10 @@ internal fun LauncherScaffold(
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
+                    .height(navBarHeight)
                     .hazeEffect(hazeState) {
                         blurRadius = 4.dp
-                        backgroundColor = config.backgroundColor
                     }
-                    .background(
-                        MaterialTheme.colorScheme.surfaceContainer.copy(alpha = MaterialTheme.transparency.background)
-                    )
-                    .navigationBarsPadding()
             )
         }
     }


### PR DESCRIPTION
Restore behavior of "Widgets on home screen" as in pre 1.37.

- Remove colored background overlay from scrims, showing only blur effect
- Remove backgroundColor tint from hazeEffect
- Remove icon color change when scrims are visible (icons now stay based on wallpaper)
- Add wallpaper blur when scrolled away from top on home screen
- Use explicit height for scrim boxes to ensure proper rendering