### PR TITLE
feat: Add latest button to sort apps by recently installed date

### DIFF
--- a/app/ui/src/main/java/de/mm20/launcher2/ui/common/FavoritesTagSelector.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/common/FavoritesTagSelector.kt
@@ -38,15 +38,16 @@ import de.mm20.launcher2.ui.layout.TopReversed
 @Composable
 fun FavoritesTagSelector(
     tags: List<Tag>,
-    selectedTag: String?,
+    selectedTarget: SelectorTarget,
     editButton: Boolean,
     reverse: Boolean,
-    onSelectTag: (String?) -> Unit,
+    onSelectTarget: (SelectorTarget) -> Unit,
     scrollState: ScrollState,
     compact: Boolean,
     expanded: Boolean,
     onExpand: (Boolean) -> Unit,
-    showFavorites: Boolean
+    showFavorites: Boolean,
+    showRecentlyInstalledApps: Boolean
 ) {
     val sheetManager = LocalBottomSheetManager.current
 
@@ -75,8 +76,8 @@ fun FavoritesTagSelector(
                         FilterChip(
                             modifier = Modifier
                                 .padding(start = 16.dp),
-                            selected = selectedTag == null,
-                            onClick = { onSelectTag(null) },
+                            selected = selectedTarget is SelectorTarget.Favorites,
+                            onClick = { onSelectTarget(SelectorTarget.Favorites) },
                             leadingIcon = if (compact) null else {
                                 {
                                     Icon(
@@ -99,17 +100,53 @@ fun FavoritesTagSelector(
                             }
                         )
                     }
+                    if (showRecentlyInstalledApps) {
+                        FilterChip(
+                            modifier = Modifier
+                                .padding(start = if (!showFavorites) 16.dp else 8.dp),
+                            selected = selectedTarget is SelectorTarget.Latest,
+                            onClick = {
+                                if (selectedTarget is SelectorTarget.Latest && showFavorites) {
+                                    onSelectTarget(SelectorTarget.Favorites)
+                                } else {
+                                    onSelectTarget(SelectorTarget.Latest)
+                                }
+                            },
+                            leadingIcon = if (compact) null else {
+                                {
+                                    Icon(
+                                        painter = painterResource(R.drawable.sort_24px),
+                                        contentDescription = null,
+                                        modifier = Modifier.size(FilterChipDefaults.IconSize),
+                                    )
+                                }
+                            },
+                            label = {
+                                if (compact) {
+                                    Icon(
+                                        painter = painterResource(R.drawable.sort_24px),
+                                        contentDescription = null,
+                                        modifier = Modifier.size(FilterChipDefaults.IconSize),
+                                    )
+                                } else {
+                                    Text(stringResource(R.string.latest))
+                                }
+                            }
+                        )
+                    }
                     for ((i, tag) in tags.withIndex()) {
+                        val selected =
+                            (selectedTarget as? SelectorTarget.CustomTag)?.tagName == tag.tag
                         TagChip(
                             modifier = Modifier
-                                .padding(start = if (!showFavorites && i == 0) 16.dp else 8.dp),
+                                .padding(start = if (!(showFavorites || showRecentlyInstalledApps) && i == 0) 16.dp else 8.dp),
                             tag = tag,
-                            selected = selectedTag == tag.tag,
+                            selected = selected,
                             onClick = {
-                                if (selectedTag == tag.tag && showFavorites) {
-                                    onSelectTag(null)
+                                if (selected && showFavorites) {
+                                    onSelectTarget(SelectorTarget.Favorites)
                                 } else {
-                                    onSelectTag(tag.tag)
+                                    onSelectTarget(SelectorTarget.CustomTag(tag.tag))
                                 }
                             },
                             compact = compact,
@@ -155,8 +192,8 @@ fun FavoritesTagSelector(
                     FilterChip(
                         modifier = Modifier
                             .padding(end = 8.dp),
-                        selected = selectedTag == null,
-                        onClick = { onSelectTag(null) },
+                        selected = selectedTarget is SelectorTarget.Favorites,
+                        onClick = { onSelectTarget(SelectorTarget.Favorites) },
                         leadingIcon = if (compact) null else {
                             {
                                 Icon(
@@ -178,18 +215,52 @@ fun FavoritesTagSelector(
                             }
                         }
                     )
+                    FilterChip(
+                        modifier = Modifier
+                            .padding(end = 8.dp),
+                        selected = selectedTarget is SelectorTarget.Latest,
+                        onClick = {
+                            if (selectedTarget is SelectorTarget.Latest && showFavorites) {
+                                onSelectTarget(SelectorTarget.Favorites)
+                            } else {
+                                onSelectTarget(SelectorTarget.Latest)
+                            }
+                        },
+                        leadingIcon = if (compact) null else {
+                            {
+                                Icon(
+                                    painter = painterResource(R.drawable.sort_24px),
+                                    contentDescription = null,
+                                    modifier = Modifier.size(FilterChipDefaults.IconSize),
+                                )
+                            }
+                        },
+                        label = {
+                            if (compact) {
+                                Icon(
+                                    painter = painterResource(R.drawable.sort_24px),
+                                    contentDescription = null,
+                                    modifier = Modifier.size(FilterChipDefaults.IconSize),
+                                )
+                            } else {
+                                Text(stringResource(R.string.latest))
+                            }
+                        }
+                    )
                     for (tag in tags) {
+                        val selected =
+                            (selectedTarget as? SelectorTarget.CustomTag)?.tagName == tag.tag
                         TagChip(
                             modifier = Modifier
                                 .padding(end = 8.dp),
                             tag = tag,
                             compact = compact,
-                            selected = selectedTag == tag.tag,
+                            selected = selected,
                             onClick = {
-                                if (selectedTag == tag.tag && showFavorites) {
-                                    onSelectTag(null)
+                                if (selected && showFavorites) {
+                                    onSelectTarget(SelectorTarget.Favorites)
                                 } else {
-                                    onSelectTag(tag.tag)
+                                    onSelectTarget(SelectorTarget.CustomTag(tag.tag))
                                 }
                             },
                             onLongClick = {

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/common/FavoritesVM.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/common/FavoritesVM.kt
@@ -2,6 +2,7 @@ package de.mm20.launcher2.ui.common
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import de.mm20.launcher2.applications.AppRepository
 import de.mm20.launcher2.data.customattrs.CustomAttributesRepository
 import de.mm20.launcher2.data.customattrs.utils.withCustomLabels
 import de.mm20.launcher2.preferences.search.FavoritesSettings
@@ -18,10 +19,12 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.transformLatest
+import kotlinx.coroutines.launch
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
@@ -31,11 +34,25 @@ abstract class FavoritesVM : ViewModel(), KoinComponent {
     internal val widgetRepository: WidgetRepository by inject()
     private val customAttributesRepository: CustomAttributesRepository by inject()
     internal val settings: FavoritesSettings by inject()
+    private val appRepository: AppRepository by inject()
 
-    val selectedTag = MutableStateFlow<String?>(null)
+    val selectedTarget = MutableStateFlow<SelectorTarget>(SelectorTarget.Favorites)
 
     val showEditButton =
         settings.showEditButton.stateIn(viewModelScope, SharingStarted.Lazily, false)
+    val showLatestButton =
+        settings.showLatestButton.stateIn(viewModelScope, SharingStarted.Lazily, false)
+    
+    init {
+        // Automatically switch back to Favorites when Latest button is hidden
+        viewModelScope.launch {
+            showLatestButton.collect { showLatest ->
+                if (!showLatest && selectedTarget.value is SelectorTarget.Latest) {
+                    selectedTarget.value = SelectorTarget.Favorites
+                }
+            }
+        }
+    }
     abstract val tagsExpanded: Flow<Boolean>
     abstract val compactTags: Flow<Boolean>
 
@@ -46,65 +63,85 @@ abstract class FavoritesVM : ViewModel(), KoinComponent {
         it.filterIsInstance<Tag>()
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(), emptyList())
 
-    open val favorites: Flow<List<SavableSearchable>> = selectedTag.flatMapLatest { tag ->
-        if (tag == null) {
-            val excludeCalendar = widgetRepository.exists(CalendarWidget.Type)
+    open val favorites: Flow<List<SavableSearchable>> = selectedTarget.flatMapLatest { selectorTarget ->
+        when (selectorTarget) {
+            is SelectorTarget.Favorites -> {
+                val excludeCalendar = widgetRepository.exists(CalendarWidget.Type)
+                combine(
+                    excludeCalendar,
+                    settings,
+                ) { (a, b) -> a as Boolean to b as FavoritesSettingsData }
+                    .transformLatest {
 
-            combine(
-                excludeCalendar,
-                settings,
-            ) { (a, b) -> a as Boolean to b as FavoritesSettingsData }
-                .transformLatest {
+                        val columns = it.second.columns
+                        val excludeCalendar = it.first
+                        val includeFrequentlyUsed = it.second.frequentlyUsed
+                        val frequentlyUsedRows = it.second.frequentlyUsedRows
 
-                    val columns = it.second.columns
-                    val excludeCalendar = it.first
-                    val includeFrequentlyUsed = it.second.frequentlyUsed
-                    val frequentlyUsedRows = it.second.frequentlyUsedRows
-
-                    val pinned = favoritesService.getFavorites(
-                        excludeTypes = if (excludeCalendar) listOf(
-                            "calendar",
-                            "tasks.org",
-                            "tag",
-                            "plugin.calendar"
-                        ) else listOf("tag"),
-                        minPinnedLevel = PinnedLevel.AutomaticallySorted,
-                        limit = 10 * columns,
-                    )
-                    if (includeFrequentlyUsed) {
-                        emitAll(pinned.flatMapLatest { pinned ->
-                            favoritesService.getFavorites(
-                                excludeTypes = if (excludeCalendar) listOf(
-                                    "calendar",
-                                    "tasks.org",
-                                    "tag",
-                                    "plugin.calendar"
-                                ) else listOf("tag"),
-                                maxPinnedLevel = PinnedLevel.FrequentlyUsed,
-                                minPinnedLevel = PinnedLevel.FrequentlyUsed,
-                                limit = frequentlyUsedRows * columns - pinned.size % columns,
-                            ).map {
-                                pinned + it
-                            }
-                                .withCustomLabels(customAttributesRepository)
-                        })
-                    } else {
-                        emitAll(
-                            pinned.withCustomLabels(customAttributesRepository)
+                        val pinned = favoritesService.getFavorites(
+                            excludeTypes = if (excludeCalendar) listOf(
+                                "calendar",
+                                "tasks.org",
+                                "tag",
+                                "plugin.calendar"
+                            ) else listOf("tag"),
+                            minPinnedLevel = PinnedLevel.AutomaticallySorted,
+                            limit = 10 * columns,
                         )
+                        if (includeFrequentlyUsed) {
+                            emitAll(pinned.flatMapLatest { pinned ->
+                                favoritesService.getFavorites(
+                                    excludeTypes = if (excludeCalendar) listOf(
+                                        "calendar",
+                                        "tasks.org",
+                                        "tag",
+                                        "plugin.calendar"
+                                    ) else listOf("tag"),
+                                    maxPinnedLevel = PinnedLevel.FrequentlyUsed,
+                                    minPinnedLevel = PinnedLevel.FrequentlyUsed,
+                                    limit = frequentlyUsedRows * columns - pinned.size % columns,
+                                ).map {
+                                    pinned + it
+                                }
+                                    .withCustomLabels(customAttributesRepository)
+                            })
+                        } else {
+                            emitAll(
+                                pinned.withCustomLabels(customAttributesRepository)
+                            )
+                        }
                     }
+            }
+            is SelectorTarget.Latest -> {
+                combine(
+                    appRepository.findMany(),
+                    settings
+                ) { apps, settingsData ->
+                    apps to settingsData
+                }.transformLatest { (apps, settingsData) ->
+                    val columns = settingsData.columns
+                    val latestRows = settingsData.latestRows
+                    val limit = latestRows * columns
+
+                    val latestApps = apps
+                        .sortedByDescending { it.firstInstallTime }
+                        .take(limit)
+
+                    emitAll(flowOf(latestApps).withCustomLabels(customAttributesRepository))
                 }
-        } else {
-            customAttributesRepository
-                .getItemsForTag(tag)
-                .withCustomLabels(customAttributesRepository)
-                .map { it.sortedBy { it } }
+            }
+            is SelectorTarget.CustomTag -> {
+                customAttributesRepository
+                    .getItemsForTag(selectorTarget.tagName)
+                    .withCustomLabels(customAttributesRepository)
+                    .map { it.sortedBy { it } }
+            }
         }
     }.shareIn(viewModelScope, SharingStarted.WhileSubscribed(), replay = 1)
 
 
-    fun selectTag(tag: String?) {
-        selectedTag.value = tag
+    fun selectTarget(target: SelectorTarget) {
+        selectedTarget.value = target
     }
 
     abstract fun setTagsExpanded(expanded: Boolean)

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/common/SelectorTarget.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/common/SelectorTarget.kt
@@ -1,0 +1,7 @@
+package de.mm20.launcher2.ui.common
+
+sealed interface SelectorTarget {
+    data object Favorites : SelectorTarget
+    data object Latest : SelectorTarget
+    data class CustomTag(val tagName: String) : SelectorTarget
+}

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/search/SearchColumn.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/search/SearchColumn.kt
@@ -35,6 +35,7 @@ import de.mm20.launcher2.search.Contact
 import de.mm20.launcher2.search.File
 import de.mm20.launcher2.search.Location
 import de.mm20.launcher2.search.Website
+import de.mm20.launcher2.ui.common.SelectorTarget
 import de.mm20.launcher2.ui.component.LauncherCard
 import de.mm20.launcher2.ui.launcher.search.apps.AppResults
 import de.mm20.launcher2.ui.launcher.search.calculator.CalculatorResults
@@ -107,9 +108,10 @@ fun SearchColumn(
     val hasProfilesPermission by viewModel.hasProfilesPermission.collectAsState(false)
 
     val pinnedTags by favoritesVM.pinnedTags.collectAsState(emptyList())
-    val selectedTag by favoritesVM.selectedTag.collectAsState(null)
+    val selectedTarget by favoritesVM.selectedTarget.collectAsState(SelectorTarget.Favorites)
     val compactTags by favoritesVM.compactTags.collectAsState(false)
     val favoritesEditButton by favoritesVM.showEditButton.collectAsState(false)
+    val showLatestButton by favoritesVM.showLatestButton.collectAsState(false)
     val favoritesTagsExpanded by favoritesVM.tagsExpanded.collectAsState(false)
 
     val expandedCategory: SearchCategory? by viewModel.expandedCategory
@@ -165,16 +167,17 @@ fun SearchColumn(
                 if (!hideFavs && favoritesEnabled) {
                     SearchFavorites(
                         favorites = favorites,
-                        selectedTag = selectedTag,
+                        selectedTarget = selectedTarget,
                         pinnedTags = pinnedTags,
                         tagsExpanded = favoritesTagsExpanded,
-                        onSelectTag = { favoritesVM.selectTag(it) },
+                        onSelectTarget = { favoritesVM.selectTarget(it) },
                         reverse = reverse,
                         onExpandTags = {
                             favoritesVM.setTagsExpanded(it)
                         },
                         compactTags = compactTags,
-                        editButton = favoritesEditButton
+                        editButton = favoritesEditButton,
+                        showLatestButton = showLatestButton
                     )
                 } else {
                     // Empty item to maintain scroll position

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/search/favorites/SearchFavorites.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/search/favorites/SearchFavorites.kt
@@ -16,6 +16,7 @@ import de.mm20.launcher2.search.SavableSearchable
 import de.mm20.launcher2.search.Tag
 import de.mm20.launcher2.ui.R
 import de.mm20.launcher2.ui.common.FavoritesTagSelector
+import de.mm20.launcher2.ui.common.SelectorTarget
 import de.mm20.launcher2.ui.component.Banner
 import de.mm20.launcher2.ui.launcher.search.common.grid.SearchResultGrid
 import de.mm20.launcher2.ui.layout.BottomReversed
@@ -24,12 +25,13 @@ import de.mm20.launcher2.ui.theme.transparency.transparency
 fun LazyListScope.SearchFavorites(
     favorites: List<SavableSearchable>,
     pinnedTags: List<Tag>,
-    selectedTag: String?,
+    selectedTarget: SelectorTarget,
     compactTags: Boolean,
     tagsExpanded: Boolean,
     onExpandTags: (Boolean) -> Unit,
-    onSelectTag: (String?) -> Unit,
+    onSelectTarget: (SelectorTarget) -> Unit,
     editButton: Boolean,
+    showLatestButton: Boolean,
     reverse: Boolean,
 ) {
     item(
@@ -52,28 +54,29 @@ fun LazyListScope.SearchFavorites(
                 verticalArrangement = if (reverse) Arrangement.BottomReversed else Arrangement.Top
             ) {
                 if (favorites.isNotEmpty()) {
-                    SearchResultGrid(favorites, transitionKey = selectedTag, reverse = reverse)
+                    SearchResultGrid(favorites, transitionKey = selectedTarget, reverse = reverse)
                 } else {
                     Banner(
                         modifier = Modifier.padding(16.dp),
                         text = stringResource(
-                            if (selectedTag == null) R.string.favorites_empty else R.string.favorites_empty_tag
+                            if (selectedTarget is SelectorTarget.Favorites) R.string.favorites_empty else R.string.favorites_empty_tag
                         ),
-                        icon = if (selectedTag == null) R.drawable.star_24px else R.drawable.tag_24px,
+                        icon = if (selectedTarget is SelectorTarget.Favorites) R.drawable.star_24px else R.drawable.tag_24px,
                     )
                 }
                 if (pinnedTags.isNotEmpty() || editButton) {
                     FavoritesTagSelector(
                         tags = pinnedTags,
-                        selectedTag = selectedTag,
+                        selectedTarget = selectedTarget,
                         editButton = editButton,
                         reverse = false,
-                        onSelectTag = onSelectTag,
+                        onSelectTarget = onSelectTarget,
                         scrollState = rememberScrollState(),
                         expanded = tagsExpanded,
                         compact = compactTags,
                         onExpand = onExpandTags,
-                        showFavorites = true
+                        showFavorites = true,
+                        showRecentlyInstalledApps = showLatestButton
                     )
                 }
             }

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/sheets/ConfigureWidgetSheet.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/sheets/ConfigureWidgetSheet.kt
@@ -510,6 +510,22 @@ fun ColumnScope.ConfigureFavoritesWidget(
                                     )
                                 }
                             )
+                            HorizontalDivider()
+                            SwitchPreference(
+                                title = stringResource(R.string.preference_latest_button),
+                                iconPadding = false,
+                                value = widget.config.latestButton,
+                                onValueChanged = {
+                                    onWidgetUpdated(
+                                        widget.copy(
+                                            config = widget.config.copy(
+                                                latestButton = it
+                                            )
+                                        )
+                                    )
+                                }
+                            )
+                            HorizontalDivider()
                             SwitchPreference(
                                 title = stringResource(R.string.preference_compact_tags),
                                 iconPadding = false,

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/widgets/favorites/AppsWidget.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/widgets/favorites/AppsWidget.kt
@@ -15,6 +15,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import de.mm20.launcher2.search.Tag
 import de.mm20.launcher2.ui.R
 import de.mm20.launcher2.ui.common.FavoritesTagSelector
+import de.mm20.launcher2.ui.common.SelectorTarget
 import de.mm20.launcher2.ui.component.Banner
 import de.mm20.launcher2.ui.launcher.search.common.grid.SearchResultGrid
 import de.mm20.launcher2.widgets.AppsWidget
@@ -24,10 +25,11 @@ fun AppsWidget(widget: AppsWidget) {
     val viewModel: AppsWidgetVM = viewModel(key = "favorites-widget-${widget.id}")
     val favorites by remember { viewModel.favorites }.collectAsState(emptyList())
     val pinnedTags by viewModel.pinnedTags.collectAsState(emptyList())
-    val selectedTag by viewModel.selectedTag.collectAsState(null)
+    val selectedTarget by viewModel.selectedTarget.collectAsState(SelectorTarget.Favorites)
 
     val customTags = widget.config.customTags && widget.config.tagList.isNotEmpty()
     val favoritesEditButton = !customTags && widget.config.editButton
+    val showRecentlyInstalledApps = !customTags && widget.config.latestButton
 
     val compactTags = widget.config.compactTags
     val tagsExpanded = widget.config.tagsMultiline
@@ -40,28 +42,29 @@ fun AppsWidget(widget: AppsWidget) {
         modifier = Modifier.padding(vertical = 4.dp)
     ) {
         if (favorites.isNotEmpty()) {
-            SearchResultGrid(favorites, transitionKey = selectedTag)
+            SearchResultGrid(favorites, transitionKey = selectedTarget)
         } else {
             Banner(
                 modifier = Modifier.padding(16.dp),
                 text = stringResource(
-                    if (selectedTag == null) R.string.favorites_empty else R.string.favorites_empty_tag
+                    if (selectedTarget is SelectorTarget.Favorites) R.string.favorites_empty else R.string.favorites_empty_tag
                 ),
-                icon = if (selectedTag == null) R.drawable.star_24px else R.drawable.tag_24px,
+                icon = if (selectedTarget is SelectorTarget.Favorites) R.drawable.star_24px else R.drawable.tag_24px,
             )
         }
-        if (favoritesEditButton || (!customTags && pinnedTags.isNotEmpty()) || (customTags && widget.config.tagList.size > 1)) {
+        if (favoritesEditButton || showRecentlyInstalledApps || (!customTags && pinnedTags.isNotEmpty()) || (customTags && widget.config.tagList.size > 1)) {
             FavoritesTagSelector(
                 tags = if (customTags) widget.config.tagList.map { Tag(it) } else pinnedTags,
-                selectedTag = selectedTag,
+                selectedTarget = selectedTarget,
                 editButton = favoritesEditButton,
                 reverse = false,
-                onSelectTag = { viewModel.selectTag(it) },
+                onSelectTarget = { viewModel.selectTarget(it) },
                 scrollState = rememberScrollState(),
                 expanded = tagsExpanded,
                 compact = compactTags,
                 onExpand = { viewModel.setTagsExpanded(it) },
-                showFavorites = !customTags
+                showFavorites = !customTags,
+                showRecentlyInstalledApps = showRecentlyInstalledApps
             )
         }
     }

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/widgets/favorites/AppsWidgetVM.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/widgets/favorites/AppsWidgetVM.kt
@@ -4,6 +4,7 @@ import de.mm20.launcher2.preferences.ui.GridSettings
 import de.mm20.launcher2.preferences.ui.UiSettings
 import de.mm20.launcher2.services.widgets.WidgetsService
 import de.mm20.launcher2.ui.common.FavoritesVM
+import de.mm20.launcher2.ui.common.SelectorTarget
 import de.mm20.launcher2.widgets.AppsWidget
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -35,7 +36,7 @@ class AppsWidgetVM : FavoritesVM() {
         }
 
     override val favorites = super.favorites.combine(clockWidgetFavSlots) { favs, slots ->
-        if (selectedTag.value == null) {
+        if (selectedTarget.value == null) {
             if (favs.lastIndex < slots) emptyList()
             else favs.subList(slots, favs.size)
         } else {
@@ -53,9 +54,9 @@ class AppsWidgetVM : FavoritesVM() {
     }
 
     fun updateWidget(widget: AppsWidget) {
-        selectTag(null)
+        selectTarget(SelectorTarget.Favorites)
         if (widget.config.customTags) {
-            selectTag(widget.config.tagList.firstOrNull())
+            selectTarget(widget.config.tagList.firstOrNull()?.let { SelectorTarget.CustomTag(it)} ?: SelectorTarget.Favorites)
         }
 
         this.widget.value = widget

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/settings/favorites/FavoritesSettingsScreen.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/settings/favorites/FavoritesSettingsScreen.kt
@@ -82,6 +82,8 @@ fun FavoritesSettingsScreen() {
         }
         item {
             val editButton by viewModel.editButton.collectAsState()
+            val latestButton by viewModel.latestButton.collectAsState()
+            val latestRows by viewModel.latestRows.collectAsState()
             val compactTags by viewModel.compactTags.collectAsState()
             PreferenceCategory {
                 SwitchPreference(
@@ -92,6 +94,26 @@ fun FavoritesSettingsScreen() {
                         viewModel.setEditButton(it)
                     },
                     icon = R.drawable.edit_24px,
+                )
+                SwitchPreference(
+                    title = stringResource(R.string.preference_latest_button),
+                    summary = stringResource(R.string.preference_latest_button_summary),
+                    value = latestButton == true,
+                    onValueChanged = {
+                        viewModel.setLatestButton(it)
+                    },
+                    icon = R.drawable.sort_24px,
+                )
+                SliderPreference(
+                    title = stringResource(R.string.preference_latest_rows),
+                    value = latestRows,
+                    enabled = latestButton == true,
+                    min = 1,
+                    max = 10,
+                    onValueChanged = {
+                        viewModel.setLatestRows(it)
+                    },
+                    icon = R.drawable.table_rows_24px,
                 )
                 SwitchPreference(
                     title = stringResource(R.string.preference_compact_tags),

--- a/app/ui/src/main/java/de/mm20/launcher2/ui/settings/favorites/FavoritesSettingsScreenVM.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/settings/favorites/FavoritesSettingsScreenVM.kt
@@ -34,6 +34,12 @@ class FavoritesSettingsScreenVM: ViewModel(), KoinComponent {
         favoritesSettings.setShowEditButton(editButton)
     }
 
+    val latestButton = favoritesSettings.showLatestButton
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), null)
+    fun setLatestButton(latestButton: Boolean) {
+        favoritesSettings.setShowLatestButton(latestButton)
+    }
+
     val searchResultWeightFactor = rankingSettings.weightFactor
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), WeightFactor.Default)
     fun setSearchResultWeightFactor(searchResultWeightFactor: WeightFactor) {
@@ -44,5 +50,11 @@ class FavoritesSettingsScreenVM: ViewModel(), KoinComponent {
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), null)
     fun setCompactTags(compactTags: Boolean) {
         favoritesSettings.setCompactTags(compactTags)
+    }
+
+    val latestRows = favoritesSettings.latestRows
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), 2)
+    fun setLatestRows(latestRows: Int) {
+        favoritesSettings.setLatestRows(latestRows)
     }
 }

--- a/core/base/src/main/java/de/mm20/launcher2/search/Application.kt
+++ b/core/base/src/main/java/de/mm20/launcher2/search/Application.kt
@@ -26,6 +26,8 @@ interface Application: SavableSearchable {
         get() = false
     val user: UserHandle
     val versionName: String?
+    val firstInstallTime: Long
+        get() = 0L
 
     override fun getPlaceholderIcon(context: Context): StaticLauncherIcon {
         return StaticLauncherIcon(

--- a/core/i18n/src/main/res/values/strings.xml
+++ b/core/i18n/src/main/res/values/strings.xml
@@ -683,6 +683,9 @@
     <string name="preference_favorites_edit_button_summary">Show a button to rearrange the favorites</string>
     <string name="preference_compact_tags">Compact tags</string>
     <string name="preference_compact_tags_summary">Hide tag labels or icons to reduce the space occupied by tags</string>
+    <string name="preference_latest_button">Latest button</string>
+    <string name="preference_latest_button_summary">Show button for recently installed apps</string>
+    <string name="preference_latest_rows">Number of rows</string>
     <string name="preference_widgets_edit_button_summary">Show a button to add, remove and rearrange widgets</string>
     <string name="preference_widgets_on_home_screen">Widgets on home screen</string>
     <string name="preference_widgets_on_home_screen_summary">Show widgets on the home screen instead of a separate page</string>
@@ -742,6 +745,7 @@
     <string name="favorites">Favorites</string>
     <string name="favorites_empty">Pinned and frequently used items will appear here</string>
     <string name="favorites_empty_tag">There are no items with this tag</string>
+    <string name="latest">Latest</string>
     <string name="frequently_used_show_in_favorites">Show in favorites</string>
     <string name="frequently_used_rows">Number of rows</string>
     <string name="preference_screen_search_actions">Quick actions</string>

--- a/core/preferences/src/main/java/de/mm20/launcher2/preferences/LauncherSettingsData.kt
+++ b/core/preferences/src/main/java/de/mm20/launcher2/preferences/LauncherSettingsData.kt
@@ -66,6 +66,8 @@ data class LauncherSettingsData internal constructor(
     val favoritesFrequentlyUsedRows: Int = 1,
     val favoritesEditButton: Boolean = true,
     val favoritesCompactTags: Boolean = false,
+    val favoritesLatestButton: Boolean = false,
+    val favoritesLatestRows: Int = 2,
 
     val searchAllApps: Boolean = true,
 

--- a/core/preferences/src/main/java/de/mm20/launcher2/preferences/search/FavoritesSettings.kt
+++ b/core/preferences/src/main/java/de/mm20/launcher2/preferences/search/FavoritesSettings.kt
@@ -9,6 +9,7 @@ data class FavoritesSettingsData(
     val columns: Int,
     val frequentlyUsed: Boolean,
     val frequentlyUsedRows: Int,
+    val latestRows: Int,
 )
 
 class FavoritesSettings internal constructor(
@@ -18,6 +19,7 @@ class FavoritesSettings internal constructor(
         columns = it.gridColumnCount,
         frequentlyUsed = it.favoritesFrequentlyUsed,
         frequentlyUsedRows = it.favoritesFrequentlyUsedRows,
+        latestRows = it.favoritesLatestRows,
     )
 }.distinctUntilChanged()) {
 
@@ -26,6 +28,13 @@ class FavoritesSettings internal constructor(
 
     fun setShowEditButton(showEditButton: Boolean) {
         dataStore.update { it.copy(favoritesEditButton = showEditButton) }
+    }
+
+    val showLatestButton
+        get() = dataStore.data.map { it.favoritesLatestButton }.distinctUntilChanged()
+
+    fun setShowLatestButton(showLatestButton: Boolean) {
+        dataStore.update { it.copy(favoritesLatestButton = showLatestButton) }
     }
 
     val frequentlyUsed: Flow<Boolean>
@@ -47,5 +56,12 @@ class FavoritesSettings internal constructor(
 
     fun setCompactTags(compactTags: Boolean) {
         dataStore.update { it.copy(favoritesCompactTags = compactTags) }
+    }
+
+    val latestRows: Flow<Int>
+        get() = dataStore.data.map { it.favoritesLatestRows }.distinctUntilChanged()
+
+    fun setLatestRows(latestRows: Int) {
+        dataStore.update { it.copy(favoritesLatestRows = latestRows) }
     }
 }

--- a/data/applications/src/main/java/de/mm20/launcher2/applications/LauncherApp.kt
+++ b/data/applications/src/main/java/de/mm20/launcher2/applications/LauncherApp.kt
@@ -38,6 +38,7 @@ internal data class LauncherApp(
     override val versionName: String?,
     override val isSuspended: Boolean = false,
     internal val userSerialNumber: Long,
+    override val firstInstallTime: Long = 0L,
     override val labelOverride: String? = null,
     override val score: ResultScore = ResultScore.Unspecified,
 ) : Application {
@@ -67,6 +68,10 @@ internal data class LauncherApp(
         ),
         isSuspended = launcherActivityInfo.applicationInfo.flags and ApplicationInfo.FLAG_SUSPENDED != 0,
         userSerialNumber = launcherActivityInfo.user.getSerialNumber(context),
+        firstInstallTime = getPackageInstallTime(
+            context,
+            launcherActivityInfo.applicationInfo.packageName
+        ),
         score = score,
     )
 
@@ -277,6 +282,14 @@ internal data class LauncherApp(
                 context.packageManager.getPackageInfo(packageName, 0).versionName
             } catch (e: PackageManager.NameNotFoundException) {
                 null
+            }
+        }
+
+        fun getPackageInstallTime(context: Context, packageName: String): Long {
+            return try {
+                context.packageManager.getPackageInfo(packageName, 0).firstInstallTime
+            } catch (e: PackageManager.NameNotFoundException) {
+                0L
             }
         }
 

--- a/data/widgets/src/main/java/de/mm20/launcher2/widgets/AppsWidget.kt
+++ b/data/widgets/src/main/java/de/mm20/launcher2/widgets/AppsWidget.kt
@@ -11,7 +11,8 @@ data class FavoritesWidgetConfig(
     val editButton: Boolean = true,
     val tagsMultiline: Boolean = false,
     val compactTags: Boolean = false,
-    val tagList: List<String> = emptyList()
+    val tagList: List<String> = emptyList(),
+    val latestButton: Boolean = false
 )
 
 data class AppsWidget(


### PR DESCRIPTION
Hello, this PR introduces the feature requested in [Latest/Recently Installed Apps (favourite like optional tab)](https://github.com/MM2-0/Kvaesitso/issues/775) #775.

As this is my first time contributing to the project, I hope I have gone in the right direction. So let me know what recommendations you have or any further direction I should take on this.


### Visible Changes

* See your most recently installed apps on the home screen
  * Enable it by going to Settings > Search > Favorites > "Latest button" (below "Edit button")
  * Choose the number of rows 1-10 (defaults to 2 once enabled)
  * It's not enabled by default
* Choose to have the latest button in the "Apps" widget (enable it in the widget settings)
  * It's not enabled by default

### Notable Code Change Explanations

* SelectorTarget
   * Because I was adding Latest alongside Favorites, I needed to pass more than `null` through `onSelectTag: (String?)` to communicate Favorite/Latest. So I added  `onSelectTarget: (SelectorTarget)` and used a sealed interface for (Favorite, Latest, and CustomTag) selector targets (see SelectorTarget.kt)
* Automatic Latest -> Favorites state update
  * When the user disables the Latest button and has selected Latest on their homescreen, it updates the value to Favorites so they don't end up still seeing the Latest apps when the button is no longer available. (see FavoritesVM.kt)
* Install Time Source
  * I got the `firstInstallTime` from `context.packageManager.getPackageInfo(packageName, 0).firstInstallTime`
    * Tested with ~200 apps, and the performance remains smooth.

### Video Demo


https://github.com/user-attachments/assets/e2ea9e58-558e-4e4f-99a2-5a59dff51ee6



---

This is the best launcher I have used so far, and I am so grateful that you made it. I am excited to have the chance to contribute back to this project!