### PR TITLE
Allow notification drawer gesture without accessibility dependency

### DIFF
--- a/services/global-actions/src/main/java/de/mm20/launcher2/globalactions/GlobalActionsService.kt
+++ b/services/global-actions/src/main/java/de/mm20/launcher2/globalactions/GlobalActionsService.kt
@@ -39,13 +39,13 @@ class GlobalActionsService(private val context: Context) {
             val method = statusBarManager.getMethod("expandNotificationsPanel")
             method.invoke(statusBarService)
         } catch (e: IllegalAccessException) {
-            Log.e("MM20", Log.getStackTraceString(e))
+            CrashReporter.logException(e)
         } catch (e: InvocationTargetException) {
-            Log.e("MM20", Log.getStackTraceString(e))
+            CrashReporter.logException(e)
         } catch (e: NoSuchMethodException) {
-            Log.e("MM20", Log.getStackTraceString(e))
+            CrashReporter.logException(e)
         } catch (e: ClassNotFoundException) {
-            Log.e("MM20", Log.getStackTraceString(e))
+            CrashReporter.logException(e)
         }
     }
 


### PR DESCRIPTION
- remove accessibility global-action fallback for notification drawer
- keep notification drawer invocation on StatusBarManager reflection path
- keep quick settings and other global actions unchanged

Closes MM2-0/Kvaesitso#1812