### PR TITLE
Instant search

### DIFF
--- a/services/search/src/main/java/de/mm20/launcher2/search/SearchService.kt
+++ b/services/search/src/main/java/de/mm20/launcher2/search/SearchService.kt
@@ -11,7 +11,6 @@ import de.mm20.launcher2.search.data.UnitConverter
 import de.mm20.launcher2.searchactions.SearchActionService
 import de.mm20.launcher2.searchactions.actions.SearchAction
 import de.mm20.launcher2.unitconverter.UnitConverterRepository
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -219,7 +218,6 @@ internal class SearchServiceImpl(
             }
             if (filters.articles) {
                 launch {
-                    delay(750)
                     articleRepository.search(query, filters.allowNetwork)
                         .combine(customAttrResults) { articles, customAttrs ->
                             if (customAttrs.wikipedia != null) articles + customAttrs.wikipedia
@@ -235,7 +233,6 @@ internal class SearchServiceImpl(
             }
             if (filters.places) {
                 launch {
-                    delay(250)
                     locationRepository.search(query, filters.allowNetwork)
                         .combine(customAttrResults) { locations, customAttrs ->
                             if (customAttrs.locations != null) locations + customAttrs.locations


### PR DESCRIPTION
### Motivation
- Remove the artificial staggered delays that caused search results to appear and then update a moment later so drawer search updates appear immediately.

### Description
- Removed `delay(750)` and `delay(250)` that preceded article and location provider searches in `services/search/src/main/java/de/mm20/launcher2/search/SearchService.kt` and removed the now-unused `kotlinx.coroutines.delay` import so those providers start emitting results without waiting.