### PR TITLE
Fix calendar widget data flash on home-press resume

### DIFF
--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/widgets/calendar/CalendarWidgetVM.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/widgets/calendar/CalendarWidgetVM.kt
@@ -22,6 +22,7 @@ import de.mm20.launcher2.widgets.CalendarWidgetConfig
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.stateIn
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
@@ -199,28 +200,36 @@ class CalendarWidgetVM : ViewModel(), KoinComponent {
         }
     }
 
-    suspend fun onActive() {
-        selectDate(LocalDate.now())
-        widgetConfig.collectLatest { config ->
-            calendarRepository.findMany(
-                from = System.currentTimeMillis(),
-                to = System.currentTimeMillis() + 14 * 24 * 60 * 60 * 1000L,
-                excludeAllDayEvents = !config.allDayEvents,
-                excludeCalendars = config.excludedCalendarIds ?: config.legacyExcludedCalendarIds?.map { "local:$it" } ?: emptyList(),
-            ).collectLatest { events ->
-                searchableRepository.getKeys(
-                    includeTypes = listOf("calendar", "tasks.org", "plugin.calendar"),
-                    maxVisibility = VisibilityLevel.SearchOnly,
-                    limit = 9999,
-                ).collectLatest { hidden ->
-                    upcomingEvents = events
-                        .filter {
-                            !hidden.contains(it.key) && !(!config.completedTasks && it.isCompleted == true)
-                        }.sortedBy { it.startTime ?: it.endTime }
+    init {
+        // Subscribe once, viewModel-scoped, so home-press resume does not tear down and
+        // re-subscribe to the calendar flow. Re-subscribing causes a brief empty emission
+        // that wipes calendarEvents and produces a visible blank flash on every resume
+        // (regression observed since v1.39.0; upstream issue #1777).
+        viewModelScope.launch {
+            widgetConfig.collectLatest { config ->
+                calendarRepository.findMany(
+                    from = System.currentTimeMillis(),
+                    to = System.currentTimeMillis() + 14 * 24 * 60 * 60 * 1000L,
+                    excludeAllDayEvents = !config.allDayEvents,
+                    excludeCalendars = config.excludedCalendarIds ?: config.legacyExcludedCalendarIds?.map { "local:$it" } ?: emptyList(),
+                ).collectLatest { events ->
+                    searchableRepository.getKeys(
+                        includeTypes = listOf("calendar", "tasks.org", "plugin.calendar"),
+                        maxVisibility = VisibilityLevel.SearchOnly,
+                        limit = 9999,
+                    ).collectLatest { hidden ->
+                        upcomingEvents = events
+                            .filter {
+                                !hidden.contains(it.key) && !(!config.completedTasks && it.isCompleted == true)
+                            }.sortedBy { it.startTime ?: it.endTime }
+                    }
                 }
             }
-
         }
+    }
+
+    fun onActive() {
+        selectDate(LocalDate.now())
     }
 
     fun requestCalendarPermission(context: AppCompatActivity) {


### PR DESCRIPTION
## Problem

Since v1.39.0, the calendar widget visibly flashes empty for ~600ms on every home-press
resume, then re-populates. Filed as #1777; this PR addresses the data-flash specifically
(not the broader save-state question that issue raised).

## Root cause

`CalendarWidget` invokes `viewModel.onActive()` inside
`LaunchedEffect(null) { lifecycleOwner.repeatOnLifecycle(Lifecycle.State.RESUMED) { ... } }`.
`repeatOnLifecycle` cancels the suspending block when the lifecycle drops below RESUMED
and re-runs it on every re-entry, which means `onActive()` is invoked once per home-press
resume cycle (RESUMED → CREATED → RESUMED).

Previously `onActive()` also performed the data subscription itself:

```kotlin
widgetConfig.collectLatest {
  calendarRepository.findMany(...).collectLatest {
    searchableRepository.getKeys(...).collectLatest {
      upcomingEvents = events.filter(...)
    }
  }
}
```

The cancellation tears down the nested flow subscriptions, and the new subscription
emits an empty list before Room delivers the real rows. That empty list propagates
`upcomingEvents = emptyList` → `updateEvents()` → `calendarEvents.value = emptyList`,
which the widget renders for ~600ms until the real query result lands.

## Fix

Move the data subscription into `CalendarWidgetVM.init {}` scoped to `viewModelScope`.
The subscription survives across resume cycles (the VM itself already survives, verified
via identical `System.identityHashCode(viewModel)` across home presses). `onActive()`
keeps the cheap `selectDate(LocalDate.now())` call so today's date still refreshes on
resume.

## Verification

Instrumented `upcomingEvents` setter on a Pixel 6 Pro running Android 16:

**Before** (every home press):
```
setter: incoming=341 previous=0   <- initial load
[home press]
setter: incoming=0   previous=341 <- empty emission on re-subscribe
setter: incoming=341 previous=0   <- real data ~650ms later
```

**After** (every home press): zero setter calls. The `viewModelScope` subscription is
not torn down; existing data stays in place. UI confirms: widget no longer flashes empty.
