### PR TITLE
Fast App Shortcut Search

### DIFF
--- a/data/appshortcuts/src/main/java/de/mm20/launcher2/appshortcuts/AppShortcutRepository.kt
+++ b/data/appshortcuts/src/main/java/de/mm20/launcher2/appshortcuts/AppShortcutRepository.kt
@@ -23,6 +23,8 @@ import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
@@ -115,62 +117,34 @@ internal class AppShortcutRepositoryImpl(
         return flags
     }
 
+    private class NormalizedShortcut(
+        val info: ShortcutInfo,
+        val normalizedLabels: List<String>,
+    )
+
     override fun search(query: String, allowNetwork: Boolean): Flow<ImmutableList<AppShortcut>> {
         if (query.length < 3) {
             return flowOf(persistentListOf())
         }
 
         val normalizedQuery = stringNormalizer.normalize(query)
+        return rawShortcuts.map { shortcuts ->
+            val filtered = shortcuts.mapIndexedNotNull { index, normalized ->
+                if (index % 8 == 0) currentCoroutineContext().ensureActive()
 
-        return combine(
-            listOf(
-                settings.enabled,
-                permissionsManager.hasPermission(PermissionGroup.AppShortcuts),
-                shortcutChangeEmitter
-            )
-        ) { it }
-            .map { (enabled, perm, _) ->
-                enabled as Boolean
-                perm as Boolean
-
-                if (enabled && perm) {
-                    val launcherApps =
-                        context.getSystemService<LauncherApps>() ?: return@map persistentListOf()
-
-
-                    val shortcutQuery = LauncherApps.ShortcutQuery()
-                    shortcutQuery.setQueryFlags(
-                        LauncherApps.ShortcutQuery.FLAG_MATCH_PINNED or
-                                LauncherApps.ShortcutQuery.FLAG_MATCH_DYNAMIC or
-                                LauncherApps.ShortcutQuery.FLAG_MATCH_MANIFEST or
-                                LauncherApps.ShortcutQuery.FLAG_MATCH_CACHED or
-                                LauncherApps.ShortcutQuery.FLAG_MATCH_PINNED_BY_ANY_LAUNCHER
-                    )
-                    val shortcuts = launcherApps.getShortcuts(shortcutQuery, Process.myUserHandle())
-                        ?.mapNotNull {
-                            val score = ResultScore.from(
-                                query = normalizedQuery,
-                                primaryFields = listOfNotNull(
-                                    it.longLabel?.toString()
-                                        ?.let { stringNormalizer.normalize(it) },
-                                    it.shortLabel?.toString()
-                                        ?.let { stringNormalizer.normalize(it) },
-                                )
-                            )
-                            if (score.score < 0.8f) return@mapNotNull null
-                            LauncherShortcut(
-                                context,
-                                it,
-                                score
-                            )
-                        } ?: emptyList()
-
-                    shortcuts.toImmutableList()
-
-                } else {
-                    persistentListOf()
-                }
-            }.flowOn(Dispatchers.Default)
+                val score = ResultScore.from(
+                    query = normalizedQuery,
+                    primaryFields = normalized.normalizedLabels,
+                )
+                if (score.score < 0.8f) return@mapIndexedNotNull null
+                LauncherShortcut(
+                    context,
+                    normalized.info,
+                    score
+                )
+            }.toImmutableList()
+            filtered
+        }.flowOn(Dispatchers.Default)
     }
 
     private val shortcutChangeEmitter = callbackFlow {
@@ -218,6 +192,45 @@ internal class AppShortcutRepositoryImpl(
             launcherApps.unregisterCallback(callback)
         }
     }.shareIn(scope, SharingStarted.WhileSubscribed(500), 1)
+
+    private val rawShortcuts: Flow<List<NormalizedShortcut>> = combine(
+        listOf(
+            settings.enabled,
+            permissionsManager.hasPermission(PermissionGroup.AppShortcuts),
+            shortcutChangeEmitter
+        )
+    ) { it }
+        .map { (enabled, perm, _) ->
+            enabled as Boolean
+            perm as Boolean
+
+            if (!enabled || !perm) return@map emptyList()
+
+            val launcherApps =
+                context.getSystemService<LauncherApps>() ?: return@map emptyList()
+
+            val shortcutQuery = LauncherApps.ShortcutQuery()
+            shortcutQuery.setQueryFlags(
+                LauncherApps.ShortcutQuery.FLAG_MATCH_PINNED or
+                        LauncherApps.ShortcutQuery.FLAG_MATCH_DYNAMIC or
+                        LauncherApps.ShortcutQuery.FLAG_MATCH_MANIFEST or
+                        LauncherApps.ShortcutQuery.FLAG_MATCH_CACHED or
+                        LauncherApps.ShortcutQuery.FLAG_MATCH_PINNED_BY_ANY_LAUNCHER
+            )
+            val result = launcherApps.getShortcuts(shortcutQuery, Process.myUserHandle()) ?: emptyList()
+            val normalized = result.map {
+                NormalizedShortcut(
+                    info = it,
+                    normalizedLabels = listOfNotNull(
+                        it.longLabel?.toString()?.let { l -> stringNormalizer.normalize(l) },
+                        it.shortLabel?.toString()?.let { l -> stringNormalizer.normalize(l) },
+                    )
+                )
+            }
+            normalized
+        }
+        .flowOn(Dispatchers.Default)
+        .shareIn(scope, SharingStarted.Eagerly, replay = 1)
 
     override suspend fun getShortcutsConfigActivities(): List<AppShortcutConfigActivity> {
         val launcherApps = context.getSystemService(Context.LAUNCHER_APPS_SERVICE) as LauncherApps

--- a/data/appshortcuts/src/main/java/de/mm20/launcher2/appshortcuts/Module.kt
+++ b/data/appshortcuts/src/main/java/de/mm20/launcher2/appshortcuts/Module.kt
@@ -8,7 +8,7 @@ import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
 val appShortcutsModule = module {
-    factory<AppShortcutRepository> { AppShortcutRepositoryImpl(androidContext(), get(), get(), get(), get()) }
+    single<AppShortcutRepository> { AppShortcutRepositoryImpl(androidContext(), get(), get(), get(), get()) }
     factory<SearchableRepository<AppShortcut>>(named<AppShortcut>()) { get<AppShortcutRepository>() }
     factory<SearchableDeserializer>(named(LauncherShortcut.Domain)) { LauncherShortcutDeserializer(androidContext()) }
     factory<SearchableDeserializer>(named(LegacyShortcut.Domain)) { LegacyShortcutDeserializer(androidContext()) }


### PR DESCRIPTION
## Fix long delays for app shortcut search results

App shortcuts often appear with a noticeable delay which is extremely annoying and it also gets worse with longer search strings.  Otherwise I love Kvaesitso so this has been bothering me for a while.

### Root cause

`AppShortcutRepositoryImpl.search()` fetches a fresh shortcut list for every search despite it being mostly static.  This would be fine but the string normalisation step (`StringNormalizer.normalize()`) is quite expensive and creates a visible delay before shortcuts are displayed.  This is made even worse since the coroutine spawned for each query can't be cancelled while it's filtering shortcuts which leads to resource contention and a multi-second delay for long search strings.

### Fix

- Split the expensive part (label normalization) out into a cached `rawShortcuts` flow. It only re-runs when
  the enabled setting, permission, or actual app shortcuts provided by the OS change (via the existing `shortcutChangeEmitter`). `search()` now just scores/filters the already-normalised cached list per query.
- Changed `AppShortcutRepository`'s Koin registration from `factory` to `single`, so the cache introduced above is app-lifetime. This matches the existing pattern used by `AppRepository`.
- Added a cooperative cancellation checkpoint every 8 items inside the filtering loop. (Probably not needed since the new flow is fast enough)

### Measured impact

Tested an a Pixel 6a on Android 17 with 157 app shortcuts:

- Average response time for app shortcut results reduced from around 700ms to 2-3ms making them at least as fast as all other search results
- Tail latency of 3-5 seconds for long search strings fixed

### Caveats

- The search cache does take several seconds to initialise on startup and on `shortcutChange` events which slightly impacts responsivness on a cold start but it only does as much work as the old flow did on each keystroke. 