### PR TITLE
don't trigger the long press gesture in the system gesture area

### DIFF
--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/scaffold/LauncherScaffold.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/scaffold/LauncherScaffold.kt
@@ -42,6 +42,7 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.systemGestures
 import androidx.compose.foundation.layout.union
 import androidx.compose.foundation.layout.waterfall
 import androidx.compose.foundation.layout.widthIn
@@ -1289,19 +1290,31 @@ internal fun LauncherScaffold(
                 bottom = filterBarHeight
             )
 
+            val systemGestureBottomInset =
+                WindowInsets.systemGestures.getBottom(LocalDensity.current)
+
             CompositionLocalProvider(
                 LocalScaffoldPage provides ScaffoldPage.Home,
             ) {
                 config.homeComponent.Component(
                     Modifier
                         .fillMaxSize()
-                        .pointerInput(wallpaperManager, config.doubleTap) {
+                        .pointerInput(
+                            wallpaperManager,
+                            config.doubleTap,
+                            config.longPress,
+                            systemGestureBottomInset,
+                        ) {
                             detectTapGestures(
                                 onDoubleTap = config.doubleTap?.let {
                                     { scope.launch { state.onDoubleTap() } }
                                 },
                                 onLongPress = config.longPress?.let {
-                                    { scope.launch { state.onLongPress() } }
+                                    { offset ->
+                                        if (offset.y < (size.height - systemGestureBottomInset).toFloat()) {
+                                            scope.launch { state.onLongPress() }
+                                        }
+                                    }
                                 },
                                 onTap = {
                                     wallpaperManager.sendWallpaperCommand(


### PR DESCRIPTION
Fixes #1998.

## What this does

The home screen's long-press handler is attached to the full surface, so a press-and-hold on the navigation handle triggers the launcher's long-press action at the same time as the system Assistant. This ignores a long press whose position falls inside the system gesture inset at the bottom of the screen, leaving the gesture working everywhere else.

```kotlin
onLongPress = config.longPress?.let {
    { offset ->
        if (offset.y < (size.height - systemGestureBottomInset).toFloat()) {
            scope.launch { state.onLongPress() }
        }
    }
},
```

`detectTapGestures` was already passing the press position and it was being discarded, so no new plumbing was needed — just the inset value, read the same way the file already reads its other insets a few hundred lines above.

## Choices I made that you may want to override

**Only the bottom inset.** In #1998 I raised that `systemGestures` also covers the left and right back-gesture strips, which could be too aggressive. Using `getBottom()` alone sidesteps that — the sides are untouched. If you would rather this used `navigationBars`, it is a one-word change.

**Unconditional, not a setting.** A press in the system's own gesture area arguably never belonged to the launcher, so this reads as a bug fix rather than something to configure. Easy to put behind a preference if you disagree.

**One extra key on `pointerInput`.** I added `config.longPress` to the key list, which previously held only `wallpaperManager` and `config.doubleTap`. Without it the block is not restarted when the long-press action changes in settings, so changing it appears not to take effect until the launcher restarts. That is the "possibly related" note from #1998 — it is a separate one-line fix riding along, and I am happy to pull it out into its own PR if you would rather keep this focused.

## Why this is a draft — it is not tested

I do not have an Android build environment set up, so **this has not been compiled or run on a device**. I have only checked it by reading: the types line up, `size` resolves from the enclosing `PointerInputScope`, and the import ordering matches the file.

That is not good enough to merge, and I did not want to present it as if it were. What still needs doing:

- [ ] Compiles
- [ ] Long press still works on the home screen proper
- [ ] Long press on the navigation handle no longer fires the launcher action
- [ ] Behaviour is sane with 3-button navigation, where the bottom gesture inset is 0
- [ ] Nothing regresses for double-tap or tap-to-wallpaper-command

I am opening it as a draft in case the approach is useful to you as a starting point, and because the readme suggests small fixes go straight to a PR. To be straight with you about where this leaves things: I am not in a position to set up an Android build environment for this, so I cannot take it further myself and I would not want it merged on my say-so. Treat it as a report with a suggested patch attached rather than a contribution waiting on review — if it is easier to take the idea and implement it your own way, or to close this and do it in your own time, please do. No attachment to the patch.
