### PR TITLE
fix grid search results padding when the search bar is at the bottom

### DIFF
--- a/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/search/common/grid/GridResults.kt
+++ b/app/ui/src/main/java/de/mm20/launcher2/ui/launcher/search/common/grid/GridResults.kt
@@ -64,6 +64,8 @@ fun <T : SavableSearchable> LazyListScope.GridResults(
 
         val isFirst = it == 0 && before == null
         val isLast = it == rows - 1 && after == null
+        val isTopRow = if (reverse) it == rows - 1 else it == 0
+        val isBottomRow = if (reverse) it == 0 else it == rows - 1
         Row(
             modifier = Modifier
                 .fillMaxWidth()
@@ -81,8 +83,8 @@ fun <T : SavableSearchable> LazyListScope.GridResults(
                     )
                 )
                 .padding(
-                    top = if (it == 0) 8.dp else 0.dp,
-                    bottom = if (it == rows - 1) 8.dp else 0.dp,
+                    top = if (isTopRow) 8.dp else 0.dp,
+                    bottom = if (isBottomRow) 8.dp else 0.dp,
                     start = if (columns == 1) 0.dp else 4.dp,
                     end = if (columns == 1) 0.dp else 4.dp,
                 )


### PR DESCRIPTION
## What this does

In search results shown as a grid, the inner 8dp padding at the top and bottom of the card was applied by row _index_ (`it == 0`, `it == rows - 1`) while everything else in the same modifier — the rounded corners, the outer section gap — already follows `reverse`. With the search bar at the bottom (`reverse = true`, the default), row 0 is the _bottom_ row, so:

| rows | top edge | between rows | bottom edge |
| ---- | -------- | ------------ | ----------- |
| 1    | 8dp      | —            | 8dp         |
| 2+   | 0dp      | 16dp         | 0dp         |

A query matching one row of apps and a query matching two look noticeably different: the two-row card has no breathing room at its edges and a 16dp hole between the rows.

The fix derives `isTopRow` / `isBottomRow` from `reverse` and pads on those instead. Single-row results and the search-bar-at-top layout are unchanged by construction (there the new values equal the old ones).

## Not tested on a device

I do not have an Android build environment set up, so this has not been compiled or run — only read. The change is two boolean locals and two substituted conditions, and `ListItemSurface` next door already handles `reverse` the same way, which is what made me confident the intent was symmetry.
